### PR TITLE
fix: ensure base branch docs available for update-docs mode

### DIFF
--- a/src/discovery.py
+++ b/src/discovery.py
@@ -24,7 +24,6 @@ from config import (
 # Import documentation index module
 from doc_index import (
     build_all_indexes,
-    checkout_docs_from_base_branch,
     commit_indexes_to_repo,
     fetch_indexes_from_main,
     find_relevant_files_from_indexes,
@@ -342,7 +341,6 @@ def find_relevant_files_optimized(diff):
     Returns:
         list: List of relevant file paths, or None to signal full scan needed
     """
-    checkout_docs_from_base_branch()
     fetch_indexes_from_main()
 
     indexes_changed = False

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -280,6 +280,8 @@ def main():
         print("Failed to set up docs environment")
         return
 
+    checkout_docs_from_base_branch()
+
     # === FILE DISCOVERY ===
     if previous_review and previous_review["review_found"] and previous_review["accepted_files"]:
         relevant_files = previous_review["accepted_files"]
@@ -300,7 +302,6 @@ def main():
                 use_index = False
 
         if not use_index:
-            checkout_docs_from_base_branch()
             file_previews = get_file_content_or_summaries()
 
             if not file_previews:


### PR DESCRIPTION
## Summary

- Moves `checkout_docs_from_base_branch()` call from inside discovery paths to right after `setup_docs_environment()`, so it runs unconditionally for all command modes
- Fixes `[update-docs]` failing to read files that only exist on main when the PR branch is stale

## Problem

Follow-up to PR #28. The `[update-docs]` flow after a previous `[review-docs]` skips discovery entirely and uses the accepted files from the review (line 284). But `checkout_docs_from_base_branch()` was only called inside the discovery paths — so it never ran for `[update-docs]` with a previous review.

Each `[review-docs]` and `[update-docs]` is a separate GitHub Actions run in a fresh container. Files added by `checkout_docs_from_base_branch()` during `[review-docs]` don't persist to the `[update-docs]` run. Without this fix, `load_full_content()` would fail for files that only exist on main.

## Changes

- `src/suggest_docs.py`: Call `checkout_docs_from_base_branch()` once after `setup_docs_environment()`, remove from fallback discovery path (now redundant)
- `src/discovery.py`: Remove call from `find_relevant_files_optimized()` and unused import (now redundant — called before discovery starts)

## Test plan

- [x] All 354 tests pass
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)