### PR TITLE
fix: resolve PR branch name for same-repo update-docs push

### DIFF
--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -50,24 +50,43 @@ from jira_integration import (
     format_feature_review_section,
     parse_feature_command,
 )
-from security_utils import run_command_safe
+from security_utils import run_command_safe, setup_git_credentials
 
 
-def _resolve_pr_branch(pr_number):
-    """Resolve the head branch name for a PR using the GitHub API."""
+def _resolve_pr_push_target(pr_number):
+    """Resolve the branch name and repo clone URL for pushing to a PR.
+
+    Returns (branch_name, clone_url) or (None, None) on failure.
+    For same-repo PRs, clone_url matches the current origin.
+    For fork PRs, clone_url points to the fork.
+    """
     if not pr_number or pr_number == "unknown":
-        return None
+        return None, None
     gh_token = os.environ.get("GH_TOKEN")
     if not gh_token:
-        return None
+        return None, None
     result = run_command_safe(
-        ["gh", "pr", "view", str(pr_number), "--json", "headRefName", "--jq", ".headRefName"],
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "headRefName,headRepository,headRepositoryOwner",
+            "--jq",
+            "[.headRefName, .headRepositoryOwner.login, .headRepository.name] | @tsv",
+        ],
         check=False,
         env={**os.environ, "GH_TOKEN": gh_token},
     )
-    if result.returncode == 0 and result.stdout.strip():
-        return result.stdout.strip()
-    return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None, None
+    parts = result.stdout.strip().split("\t")
+    if len(parts) != 3:
+        return None, None
+    branch, owner, repo = parts
+    clone_url = f"https://github.com/{owner}/{repo}.git"
+    return branch, clone_url
 
 
 def main():
@@ -420,7 +439,7 @@ def main():
                         for f in modified_files
                     ]
 
-                    pr_branch = _resolve_pr_branch(pr_number)
+                    pr_branch, pr_repo_url = _resolve_pr_push_target(pr_number)
                     commit_msg = "docs: update documentation based on code changes"
                     if commit_info:
                         commit_msg += "\n\nAssisted-by: code-to-docs AI"
@@ -436,6 +455,19 @@ def main():
                     elif not pr_branch:
                         print("Warning: Could not resolve PR branch name, cannot push")
                     else:
+                        origin_url = run_command_safe(
+                            ["git", "config", "--get", "remote.origin.url"], check=False
+                        )
+                        current_origin = (
+                            origin_url.stdout.strip() if origin_url.returncode == 0 else ""
+                        )
+
+                        if pr_repo_url and pr_repo_url != current_origin:
+                            setup_git_credentials(gh_token, pr_repo_url)
+                            run_command_safe(
+                                ["git", "remote", "set-url", "origin", pr_repo_url], check=True
+                            )
+
                         run_command_safe(
                             ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
                             check=True,

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -18,6 +18,7 @@ All business logic lives in dedicated modules:
 import argparse
 import difflib
 import os
+import re
 from pathlib import Path
 
 from comments import (
@@ -96,6 +97,10 @@ def _resolve_pr_push_target(pr_number):
         return None, None
     branch, owner, repo = parts
     if not branch or not owner or not repo or "null" in (owner, repo):
+        return None, None
+    _GITHUB_NAME = re.compile(r"^[a-zA-Z0-9._-]+$")
+    if not _GITHUB_NAME.match(owner) or not _GITHUB_NAME.match(repo):
+        print(f"Warning: Invalid owner/repo from PR metadata: {owner}/{repo}")
         return None, None
     clone_url = f"https://github.com/{owner}/{repo}.git"
     return branch, clone_url

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -53,13 +53,17 @@ from jira_integration import (
 )
 from security_utils import run_command_safe, setup_git_credentials
 
+_GITHUB_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+
 
 def _normalize_github_url(url):
     """Normalize a GitHub URL to https://github.com/owner/repo for comparison."""
     url = url.strip().rstrip("/")
     if url.endswith(".git"):
         url = url[:-4]
-    if url.startswith("git@github.com:"):
+    if url.startswith("ssh://git@github.com/"):
+        url = "https://github.com/" + url[len("ssh://git@github.com/") :]
+    elif url.startswith("git@github.com:"):
         url = "https://github.com/" + url[len("git@github.com:") :]
     return url
 
@@ -98,8 +102,7 @@ def _resolve_pr_push_target(pr_number):
     branch, owner, repo = parts
     if not branch or not owner or not repo or "null" in (branch, owner, repo):
         return None, None
-    _GITHUB_NAME = re.compile(r"^[a-zA-Z0-9._-]+$")
-    if not _GITHUB_NAME.match(owner) or not _GITHUB_NAME.match(repo):
+    if not _GITHUB_NAME_RE.match(owner) or not _GITHUB_NAME_RE.match(repo):
         print(f"Warning: Invalid owner/repo from PR metadata: {owner}/{repo}")
         return None, None
     clone_url = f"https://github.com/{owner}/{repo}.git"

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -492,19 +492,23 @@ def main():
                                 run_command_safe(
                                     ["git", "remote", "set-url", "origin", pr_repo_url], check=True
                                 )
-
-                        try:
+                                try:
+                                    run_command_safe(
+                                        ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
+                                        check=True,
+                                    )
+                                    print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
+                                finally:
+                                    run_command_safe(
+                                        ["git", "remote", "set-url", "origin", current_origin],
+                                        check=False,
+                                    )
+                        else:
                             run_command_safe(
                                 ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
                                 check=True,
                             )
                             print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
-                        finally:
-                            if is_fork and current_origin:
-                                run_command_safe(
-                                    ["git", "remote", "set-url", "origin", current_origin],
-                                    check=False,
-                                )
                 else:
                     print("Separate-repo scenario: creating PR...")
                     push_and_open_pr(modified_files, commit_info)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -53,6 +53,23 @@ from jira_integration import (
 from security_utils import run_command_safe
 
 
+def _resolve_pr_branch(pr_number):
+    """Resolve the head branch name for a PR using the GitHub API."""
+    if not pr_number or pr_number == "unknown":
+        return None
+    gh_token = os.environ.get("GH_TOKEN")
+    if not gh_token:
+        return None
+    result = run_command_safe(
+        ["gh", "pr", "view", str(pr_number), "--json", "headRefName", "--jq", ".headRefName"],
+        check=False,
+        env={**os.environ, "GH_TOKEN": gh_token},
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -403,7 +420,7 @@ def main():
                         for f in modified_files
                     ]
 
-                    pr_head_ref = os.environ.get("PR_HEAD_SHA", "")
+                    pr_branch = _resolve_pr_branch(pr_number)
                     commit_msg = "docs: update documentation based on code changes"
                     if commit_info:
                         commit_msg += "\n\nAssisted-by: code-to-docs AI"
@@ -416,16 +433,14 @@ def main():
                         print(
                             "Warning: GH_TOKEN not set, doc updates committed locally but not pushed"
                         )
-                    elif not pr_head_ref:
-                        print(
-                            "Warning: PR_HEAD_SHA not set, cannot determine target branch for push"
-                        )
+                    elif not pr_branch:
+                        print("Warning: Could not resolve PR branch name, cannot push")
                     else:
                         run_command_safe(
-                            ["git", "push", "origin", f"HEAD:{pr_head_ref}"],
+                            ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
                             check=True,
                         )
-                        print(f"✅ Pushed doc updates to PR branch ({pr_head_ref})")
+                        print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
                 else:
                     print("Separate-repo scenario: creating PR...")
                     push_and_open_pr(modified_files, commit_info)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -96,7 +96,7 @@ def _resolve_pr_push_target(pr_number):
     if len(parts) != 3:
         return None, None
     branch, owner, repo = parts
-    if not branch or not owner or not repo or "null" in (owner, repo):
+    if not branch or not owner or not repo or "null" in (branch, owner, repo):
         return None, None
     _GITHUB_NAME = re.compile(r"^[a-zA-Z0-9._-]+$")
     if not _GITHUB_NAME.match(owner) or not _GITHUB_NAME.match(repo):
@@ -479,19 +479,32 @@ def main():
                             origin_url.stdout.strip() if origin_url.returncode == 0 else ""
                         )
 
-                        if pr_repo_url and _normalize_github_url(
+                        is_fork = pr_repo_url and _normalize_github_url(
                             pr_repo_url
-                        ) != _normalize_github_url(current_origin):
-                            setup_git_credentials(gh_token, pr_repo_url)
-                            run_command_safe(
-                                ["git", "remote", "set-url", "origin", pr_repo_url], check=True
-                            )
+                        ) != _normalize_github_url(current_origin)
 
-                        run_command_safe(
-                            ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
-                            check=True,
-                        )
-                        print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
+                        if is_fork:
+                            if not setup_git_credentials(gh_token, pr_repo_url):
+                                print(
+                                    "Warning: Failed to configure credentials for fork, cannot push"
+                                )
+                            else:
+                                run_command_safe(
+                                    ["git", "remote", "set-url", "origin", pr_repo_url], check=True
+                                )
+
+                        try:
+                            run_command_safe(
+                                ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
+                                check=True,
+                            )
+                            print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
+                        finally:
+                            if is_fork and current_origin:
+                                run_command_safe(
+                                    ["git", "remote", "set-url", "origin", current_origin],
+                                    check=False,
+                                )
                 else:
                     print("Separate-repo scenario: creating PR...")
                     push_and_open_pr(modified_files, commit_info)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -483,9 +483,12 @@ def main():
                             origin_url.stdout.strip() if origin_url.returncode == 0 else ""
                         )
 
-                        is_fork = pr_repo_url and _normalize_github_url(
+                        is_fork = (
                             pr_repo_url
-                        ) != _normalize_github_url(current_origin)
+                            and current_origin
+                            and _normalize_github_url(pr_repo_url)
+                            != _normalize_github_url(current_origin)
+                        )
 
                         try:
                             if is_fork:

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -19,6 +19,7 @@ import argparse
 import difflib
 import os
 import re
+import subprocess
 from pathlib import Path
 
 from comments import (
@@ -486,32 +487,44 @@ def main():
                             pr_repo_url
                         ) != _normalize_github_url(current_origin)
 
-                        if is_fork:
-                            if not setup_git_credentials(gh_token, pr_repo_url):
-                                print(
-                                    "Warning: Failed to configure credentials for fork, cannot push"
-                                )
-                            else:
-                                run_command_safe(
-                                    ["git", "remote", "set-url", "origin", pr_repo_url], check=True
-                                )
-                                try:
+                        try:
+                            if is_fork:
+                                if not setup_git_credentials(gh_token, pr_repo_url):
+                                    print(
+                                        "Warning: Failed to configure credentials for fork, cannot push"
+                                    )
+                                else:
                                     run_command_safe(
-                                        ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
+                                        ["git", "remote", "set-url", "origin", pr_repo_url],
                                         check=True,
                                     )
-                                    print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
-                                finally:
-                                    run_command_safe(
-                                        ["git", "remote", "set-url", "origin", current_origin],
-                                        check=False,
-                                    )
-                        else:
-                            run_command_safe(
-                                ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
-                                check=True,
+                                    try:
+                                        run_command_safe(
+                                            [
+                                                "git",
+                                                "push",
+                                                "origin",
+                                                f"HEAD:refs/heads/{pr_branch}",
+                                            ],
+                                            check=True,
+                                        )
+                                        print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
+                                    finally:
+                                        run_command_safe(
+                                            ["git", "remote", "set-url", "origin", current_origin],
+                                            check=False,
+                                        )
+                            else:
+                                run_command_safe(
+                                    ["git", "push", "origin", f"HEAD:refs/heads/{pr_branch}"],
+                                    check=True,
+                                )
+                                print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
+                        except subprocess.CalledProcessError as e:
+                            print(
+                                f"Warning: Failed to push doc updates: {e}. "
+                                "Check that GH_PAT has repo scope and the PR allows maintainer pushes."
                             )
-                            print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
                 else:
                     print("Separate-repo scenario: creating PR...")
                     push_and_open_pr(modified_files, commit_info)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -53,6 +53,16 @@ from jira_integration import (
 from security_utils import run_command_safe, setup_git_credentials
 
 
+def _normalize_github_url(url):
+    """Normalize a GitHub URL to https://github.com/owner/repo for comparison."""
+    url = url.strip().rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    if url.startswith("git@github.com:"):
+        url = "https://github.com/" + url[len("git@github.com:") :]
+    return url
+
+
 def _resolve_pr_push_target(pr_number):
     """Resolve the branch name and repo clone URL for pushing to a PR.
 
@@ -85,6 +95,8 @@ def _resolve_pr_push_target(pr_number):
     if len(parts) != 3:
         return None, None
     branch, owner, repo = parts
+    if not branch or not owner or not repo or "null" in (owner, repo):
+        return None, None
     clone_url = f"https://github.com/{owner}/{repo}.git"
     return branch, clone_url
 
@@ -462,7 +474,9 @@ def main():
                             origin_url.stdout.strip() if origin_url.returncode == 0 else ""
                         )
 
-                        if pr_repo_url and pr_repo_url != current_origin:
+                        if pr_repo_url and _normalize_github_url(
+                            pr_repo_url
+                        ) != _normalize_github_url(current_origin):
                             setup_git_credentials(gh_token, pr_repo_url)
                             run_command_safe(
                                 ["git", "remote", "set-url", "origin", pr_repo_url], check=True

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -6,7 +6,105 @@ from unittest.mock import MagicMock, patch
 # Stub openai before any script imports config
 sys.modules.setdefault("openai", MagicMock())
 
-from suggest_docs import main
+from suggest_docs import _normalize_github_url, _resolve_pr_push_target, main
+
+# ── _normalize_github_url ────────────────────────────────────────────────────
+
+
+class TestNormalizeGithubUrl:
+    def test_https_with_git_suffix(self):
+        assert (
+            _normalize_github_url("https://github.com/org/repo.git")
+            == "https://github.com/org/repo"
+        )
+
+    def test_https_without_git_suffix(self):
+        assert _normalize_github_url("https://github.com/org/repo") == "https://github.com/org/repo"
+
+    def test_ssh_shorthand(self):
+        assert _normalize_github_url("git@github.com:org/repo.git") == "https://github.com/org/repo"
+
+    def test_ssh_protocol(self):
+        assert (
+            _normalize_github_url("ssh://git@github.com/org/repo.git")
+            == "https://github.com/org/repo"
+        )
+
+    def test_trailing_slash(self):
+        assert (
+            _normalize_github_url("https://github.com/org/repo/") == "https://github.com/org/repo"
+        )
+
+    def test_whitespace(self):
+        assert (
+            _normalize_github_url("  https://github.com/org/repo  ")
+            == "https://github.com/org/repo"
+        )
+
+
+# ── _resolve_pr_push_target ─────────────────────────────────────────────────
+
+
+class TestResolvePrPushTarget:
+    def test_returns_none_without_pr_number(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        assert _resolve_pr_push_target(None) == (None, None)
+        assert _resolve_pr_push_target("") == (None, None)
+        assert _resolve_pr_push_target("unknown") == (None, None)
+
+    def test_returns_none_without_gh_token(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_none_on_command_failure(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_none_on_null_owner_repo(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="my-branch\tnull\tnull")
+            assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_none_on_null_branch(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="null\towner\trepo")
+            assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_none_on_invalid_owner(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="branch\tbad owner!\trepo")
+            assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_none_on_malformed_output(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="only-one-field")
+            assert _resolve_pr_push_target("42") == (None, None)
+
+    def test_returns_branch_and_url_on_success(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="fix/my-branch\tfork-owner\tmy-project"
+            )
+            branch, url = _resolve_pr_push_target("42")
+        assert branch == "fix/my-branch"
+        assert url == "https://github.com/fork-owner/my-project.git"
+
+    def test_branch_with_slashes(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="feature/deep/nested/branch\towner\trepo"
+            )
+            branch, _ = _resolve_pr_push_target("42")
+        assert branch == "feature/deep/nested/branch"
+
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- The same-repo `[update-docs]` push used `PR_HEAD_SHA` (a commit SHA) as the git push ref target, creating a dangling ref instead of pushing to the PR branch
- For fork PRs, origin points to the base repo after the workflow's "Rebind Origin" step, so the push would go to the wrong repo
- Replace with `_resolve_pr_push_target()` which resolves both the branch name and head repo URL via `gh pr view`, detects fork PRs by comparing against the current origin, and re-points origin to the fork when needed

## Changes

**`src/suggest_docs.py`:**
- `_normalize_github_url()` — strips `.git` suffix and converts SSH to HTTPS for URL comparison
- `_resolve_pr_push_target()` — queries `gh pr view` for `headRefName`, `headRepositoryOwner`, `headRepository`; validates owner/repo with regex; rejects null fields (deleted forks); returns `(branch, clone_url)`
- Push logic: compares normalized head repo URL against current origin; if different (fork PR), configures credentials and re-points origin to the fork before pushing

## Scenarios handled

| Scenario | Behavior |
|----------|----------|
| Same-repo PR | Resolves branch name, pushes to origin (unchanged) |
| Fork PR | Detects different owner, re-points origin to fork, pushes to fork branch |
| Deleted fork | Null fields detected, returns warning, skips push |
| SSH origin URL | Normalized to HTTPS for comparison |
| Origin with/without `.git` | Normalized for comparison |
| Invalid owner/repo chars | Regex validation rejects, skips push |

## Test plan

- [x] Lint and format clean
- [x] Related tests pass (test_suggest_docs.py)
- [x] `gh pr view` jq expression verified on real fork PRs
- [x] URL normalization verified across formats (.git, no .git, SSH)
- [x] `maintainerCanModify: true` confirmed on consumer PRs

Generated with [Claude Code](https://claude.com/claude-code)