### PR TITLE
feat: open docs PR when update-docs runs on merged PRs

### DIFF
--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -70,17 +70,17 @@ def _normalize_github_url(url):
 
 
 def _resolve_pr_push_target(pr_number):
-    """Resolve the branch name and repo clone URL for pushing to a PR.
+    """Resolve the branch name, repo clone URL, and merge state for a PR.
 
-    Returns (branch_name, clone_url) or (None, None) on failure.
+    Returns (branch_name, clone_url, is_merged) or (None, None, False) on failure.
     For same-repo PRs, clone_url matches the current origin.
     For fork PRs, clone_url points to the fork.
     """
     if not pr_number or pr_number == "unknown":
-        return None, None
+        return None, None, False
     gh_token = os.environ.get("GH_TOKEN")
     if not gh_token:
-        return None, None
+        return None, None, False
     result = run_command_safe(
         [
             "gh",
@@ -88,26 +88,26 @@ def _resolve_pr_push_target(pr_number):
             "view",
             str(pr_number),
             "--json",
-            "headRefName,headRepository,headRepositoryOwner",
+            "headRefName,headRepository,headRepositoryOwner,state",
             "--jq",
-            "[.headRefName, .headRepositoryOwner.login, .headRepository.name] | @tsv",
+            "[.headRefName, .headRepositoryOwner.login, .headRepository.name, .state] | @tsv",
         ],
         check=False,
         env={**os.environ, "GH_TOKEN": gh_token},
     )
     if result.returncode != 0 or not result.stdout.strip():
-        return None, None
+        return None, None, False
     parts = result.stdout.strip().split("\t")
-    if len(parts) != 3:
-        return None, None
-    branch, owner, repo = parts
+    if len(parts) != 4:
+        return None, None, False
+    branch, owner, repo, state = parts
     if not branch or not owner or not repo or "null" in (branch, owner, repo):
-        return None, None
+        return None, None, False
     if not _GITHUB_NAME_RE.match(owner) or not _GITHUB_NAME_RE.match(repo):
         print(f"Warning: Invalid owner/repo from PR metadata: {owner}/{repo}")
-        return None, None
+        return None, None, False
     clone_url = f"https://github.com/{owner}/{repo}.git"
-    return branch, clone_url
+    return branch, clone_url, state == "MERGED"
 
 
 def main():
@@ -460,7 +460,8 @@ def main():
                         for f in modified_files
                     ]
 
-                    pr_branch, pr_repo_url = _resolve_pr_push_target(pr_number)
+                    pr_branch, pr_repo_url, pr_merged = _resolve_pr_push_target(pr_number)
+                    docs_pr_url = None
                     commit_msg = "docs: update documentation based on code changes"
                     if commit_info:
                         commit_msg += "\n\nAssisted-by: code-to-docs AI"
@@ -475,6 +476,79 @@ def main():
                         )
                     elif not pr_branch:
                         print("Warning: Could not resolve PR branch name, cannot push")
+                    elif pr_merged:
+                        base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+                        docs_branch = f"docs/update-from-pr-{pr_number}"
+                        docs_pr_url = None
+                        print(f"PR is merged — creating docs PR against {base_branch}...")
+                        try:
+                            run_command_safe(["git", "checkout", "-B", docs_branch], check=True)
+                            run_command_safe(
+                                [
+                                    "git",
+                                    "push",
+                                    "--set-upstream",
+                                    "origin",
+                                    docs_branch,
+                                    "--force-with-lease",
+                                ],
+                                check=True,
+                            )
+                            pr_body = (
+                                f"Documentation updates based on merged PR #{pr_number}.\n\n"
+                                "Files updated:\n"
+                                + "\n".join([f"- `{f}`" for f in docs_files])
+                                + "\n\n*Assisted by code-to-docs AI*"
+                            )
+                            check_pr = run_command_safe(
+                                [
+                                    "gh",
+                                    "pr",
+                                    "list",
+                                    "--head",
+                                    docs_branch,
+                                    "--state",
+                                    "open",
+                                    "--json",
+                                    "number,url",
+                                ],
+                                check=False,
+                                env={**os.environ, "GH_TOKEN": gh_token},
+                            )
+                            existing_pr = (
+                                check_pr.stdout.strip() if check_pr.returncode == 0 else "[]"
+                            )
+                            if existing_pr and existing_pr != "[]":
+                                import json as _json
+
+                                try:
+                                    docs_pr_url = _json.loads(existing_pr)[0].get("url")
+                                except (ValueError, IndexError, KeyError):
+                                    pass
+                                print(f"✅ Updated existing docs PR (branch {docs_branch})")
+                            else:
+                                create_result = run_command_safe(
+                                    [
+                                        "gh",
+                                        "pr",
+                                        "create",
+                                        "--title",
+                                        f"docs: update documentation from PR #{pr_number}",
+                                        "--body",
+                                        pr_body,
+                                        "--base",
+                                        base_branch,
+                                        "--head",
+                                        docs_branch,
+                                    ],
+                                    check=True,
+                                    env={**os.environ, "GH_TOKEN": gh_token},
+                                )
+                                if create_result.stdout.strip():
+                                    docs_pr_url = create_result.stdout.strip()
+                                print(f"✅ Created docs PR (branch {docs_branch})")
+                        except subprocess.CalledProcessError as e:
+                            print(f"Warning: Failed to create docs PR: {e}")
                     else:
                         origin_url = run_command_safe(
                             ["git", "config", "--get", "remote.origin.url"], check=False
@@ -583,7 +657,11 @@ def main():
                             confirm_parts.append("</details>")
                             confirm_parts.append("")
                     docs_subfolder = os.environ.get("DOCS_SUBFOLDER")
-                    if docs_subfolder:
+                    if docs_subfolder and pr_merged and docs_pr_url:
+                        confirm_parts.append(f"A docs PR has been created: {docs_pr_url}")
+                    elif docs_subfolder and pr_merged:
+                        confirm_parts.append("A docs PR has been created with these changes.")
+                    elif docs_subfolder:
                         confirm_parts.append("Doc updates have been committed to this PR.")
                     else:
                         confirm_parts.append(

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -114,12 +114,14 @@ def _resolve_pr_push_target(pr_number):
 def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
     """Create a docs PR for a merged source PR.
 
-    Returns the docs PR URL on success, or None on failure.
+    Returns the docs PR URL on success (empty string if URL could not
+    be extracted), or None on failure.
     """
     base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
     docs_branch = f"docs/update-from-pr-{pr_number}"
     print(f"PR is merged — creating docs PR against {base_branch}...")
     try:
+        run_command_safe(["git", "fetch", "origin", docs_branch], check=False)
         run_command_safe(["git", "checkout", "-B", docs_branch], check=True)
         run_command_safe(
             ["git", "push", "--set-upstream", "origin", docs_branch, "--force-with-lease"],
@@ -139,9 +141,9 @@ def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
         existing_pr = check_pr.stdout.strip() if check_pr.returncode == 0 else "[]"
         if existing_pr and existing_pr != "[]":
             try:
-                url = json.loads(existing_pr)[0].get("url")
+                url = json.loads(existing_pr)[0].get("url", "")
             except (ValueError, IndexError, KeyError):
-                url = None
+                url = ""
             print(f"✅ Updated existing docs PR (branch {docs_branch})")
             return url
 
@@ -162,7 +164,7 @@ def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
             check=True,
             env={**os.environ, "GH_TOKEN": gh_token},
         )
-        url = create_result.stdout.strip() if create_result.stdout.strip() else None
+        url = create_result.stdout.strip() or ""
         print(f"✅ Created docs PR (branch {docs_branch})")
         return url
     except subprocess.CalledProcessError as e:
@@ -522,6 +524,7 @@ def main():
 
                     pr_branch, pr_repo_url, pr_merged = _resolve_pr_push_target(pr_number)
                     docs_pr_url = None
+                    docs_pr_failed = False
                     commit_msg = "docs: update documentation based on code changes"
                     if commit_info:
                         commit_msg += "\n\nAssisted-by: code-to-docs AI"
@@ -538,8 +541,8 @@ def main():
                         print("Warning: Could not resolve PR branch name, cannot push")
                     elif pr_merged:
                         docs_pr_url = _push_docs_pr_for_merged(pr_number, docs_files, gh_token)
-                        if not docs_pr_url:
-                            pr_merged = False
+                        if docs_pr_url is None:
+                            docs_pr_failed = True
                     else:
                         origin_url = run_command_safe(
                             ["git", "config", "--get", "remote.origin.url"], check=False
@@ -648,7 +651,11 @@ def main():
                             confirm_parts.append("</details>")
                             confirm_parts.append("")
                     docs_subfolder = os.environ.get("DOCS_SUBFOLDER")
-                    if docs_subfolder and pr_merged and docs_pr_url:
+                    if docs_subfolder and pr_merged and docs_pr_failed:
+                        confirm_parts.append(
+                            "Failed to create a docs PR. The changes are shown above for manual application."
+                        )
+                    elif docs_subfolder and pr_merged and docs_pr_url:
                         confirm_parts.append(f"A docs PR has been created: {docs_pr_url}")
                     elif docs_subfolder and pr_merged:
                         confirm_parts.append("A docs PR has been created with these changes.")

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -141,9 +141,18 @@ def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
         existing_pr = check_pr.stdout.strip() if check_pr.returncode == 0 else "[]"
         if existing_pr and existing_pr != "[]":
             try:
-                url = json.loads(existing_pr)[0].get("url", "")
+                pr_data = json.loads(existing_pr)[0]
+                url = pr_data.get("url", "")
+                pr_num = pr_data.get("number")
             except (ValueError, IndexError, KeyError):
                 url = ""
+                pr_num = None
+            if pr_num:
+                run_command_safe(
+                    ["gh", "pr", "edit", str(pr_num), "--body", pr_body],
+                    check=False,
+                    env={**os.environ, "GH_TOKEN": gh_token},
+                )
             print(f"✅ Updated existing docs PR (branch {docs_branch})")
             return url
 

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -145,8 +145,8 @@ def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
                 url = pr_data.get("url", "")
                 pr_num = pr_data.get("number")
             except (ValueError, IndexError, KeyError):
-                url = ""
-                pr_num = None
+                print(f"Warning: Could not parse existing PR data for {docs_branch}")
+                return None
             if pr_num:
                 run_command_safe(
                     ["gh", "pr", "edit", str(pr_num), "--body", pr_body],

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -17,6 +17,7 @@ All business logic lives in dedicated modules:
 
 import argparse
 import difflib
+import json
 import os
 import re
 import subprocess
@@ -108,6 +109,65 @@ def _resolve_pr_push_target(pr_number):
         return None, None, False
     clone_url = f"https://github.com/{owner}/{repo}.git"
     return branch, clone_url, state == "MERGED"
+
+
+def _push_docs_pr_for_merged(pr_number, docs_files, gh_token):
+    """Create a docs PR for a merged source PR.
+
+    Returns the docs PR URL on success, or None on failure.
+    """
+    base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+    docs_branch = f"docs/update-from-pr-{pr_number}"
+    print(f"PR is merged — creating docs PR against {base_branch}...")
+    try:
+        run_command_safe(["git", "checkout", "-B", docs_branch], check=True)
+        run_command_safe(
+            ["git", "push", "--set-upstream", "origin", docs_branch, "--force-with-lease"],
+            check=True,
+        )
+        pr_body = (
+            f"Documentation updates based on merged PR #{pr_number}.\n\n"
+            "Files updated:\n"
+            + "\n".join([f"- `{f}`" for f in docs_files])
+            + "\n\n*Assisted by code-to-docs AI*"
+        )
+        check_pr = run_command_safe(
+            ["gh", "pr", "list", "--head", docs_branch, "--state", "open", "--json", "number,url"],
+            check=False,
+            env={**os.environ, "GH_TOKEN": gh_token},
+        )
+        existing_pr = check_pr.stdout.strip() if check_pr.returncode == 0 else "[]"
+        if existing_pr and existing_pr != "[]":
+            try:
+                url = json.loads(existing_pr)[0].get("url")
+            except (ValueError, IndexError, KeyError):
+                url = None
+            print(f"✅ Updated existing docs PR (branch {docs_branch})")
+            return url
+
+        create_result = run_command_safe(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                f"docs: update documentation from PR #{pr_number}",
+                "--body",
+                pr_body,
+                "--base",
+                base_branch,
+                "--head",
+                docs_branch,
+            ],
+            check=True,
+            env={**os.environ, "GH_TOKEN": gh_token},
+        )
+        url = create_result.stdout.strip() if create_result.stdout.strip() else None
+        print(f"✅ Created docs PR (branch {docs_branch})")
+        return url
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Failed to create docs PR: {e}")
+        return None
 
 
 def main():
@@ -477,78 +537,9 @@ def main():
                     elif not pr_branch:
                         print("Warning: Could not resolve PR branch name, cannot push")
                     elif pr_merged:
-                        base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
-                        docs_branch = f"docs/update-from-pr-{pr_number}"
-                        docs_pr_url = None
-                        print(f"PR is merged — creating docs PR against {base_branch}...")
-                        try:
-                            run_command_safe(["git", "checkout", "-B", docs_branch], check=True)
-                            run_command_safe(
-                                [
-                                    "git",
-                                    "push",
-                                    "--set-upstream",
-                                    "origin",
-                                    docs_branch,
-                                    "--force-with-lease",
-                                ],
-                                check=True,
-                            )
-                            pr_body = (
-                                f"Documentation updates based on merged PR #{pr_number}.\n\n"
-                                "Files updated:\n"
-                                + "\n".join([f"- `{f}`" for f in docs_files])
-                                + "\n\n*Assisted by code-to-docs AI*"
-                            )
-                            check_pr = run_command_safe(
-                                [
-                                    "gh",
-                                    "pr",
-                                    "list",
-                                    "--head",
-                                    docs_branch,
-                                    "--state",
-                                    "open",
-                                    "--json",
-                                    "number,url",
-                                ],
-                                check=False,
-                                env={**os.environ, "GH_TOKEN": gh_token},
-                            )
-                            existing_pr = (
-                                check_pr.stdout.strip() if check_pr.returncode == 0 else "[]"
-                            )
-                            if existing_pr and existing_pr != "[]":
-                                import json as _json
-
-                                try:
-                                    docs_pr_url = _json.loads(existing_pr)[0].get("url")
-                                except (ValueError, IndexError, KeyError):
-                                    pass
-                                print(f"✅ Updated existing docs PR (branch {docs_branch})")
-                            else:
-                                create_result = run_command_safe(
-                                    [
-                                        "gh",
-                                        "pr",
-                                        "create",
-                                        "--title",
-                                        f"docs: update documentation from PR #{pr_number}",
-                                        "--body",
-                                        pr_body,
-                                        "--base",
-                                        base_branch,
-                                        "--head",
-                                        docs_branch,
-                                    ],
-                                    check=True,
-                                    env={**os.environ, "GH_TOKEN": gh_token},
-                                )
-                                if create_result.stdout.strip():
-                                    docs_pr_url = create_result.stdout.strip()
-                                print(f"✅ Created docs PR (branch {docs_branch})")
-                        except subprocess.CalledProcessError as e:
-                            print(f"Warning: Failed to create docs PR: {e}")
+                        docs_pr_url = _push_docs_pr_for_merged(pr_number, docs_files, gh_token)
+                        if not docs_pr_url:
+                            pr_merged = False
                     else:
                         origin_url = run_command_safe(
                             ["git", "config", "--get", "remote.origin.url"], check=False

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -175,11 +175,11 @@ class TestPushDocsPrForMerged:
             result = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
         assert result is None
 
-    def test_existing_pr_bad_json_returns_empty(self):
+    def test_existing_pr_bad_json_returns_none(self):
         side_effect, _ = self._mock_run(pr_list_stdout="not-json")
         with patch("suggest_docs.run_command_safe", side_effect=side_effect):
-            url = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
-        assert url == ""
+            result = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert result is None
 
     def test_create_empty_stdout_returns_empty(self):
         side_effect, _ = self._mock_run(create_stdout="")

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -48,62 +48,74 @@ class TestNormalizeGithubUrl:
 class TestResolvePrPushTarget:
     def test_returns_none_without_pr_number(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
-        assert _resolve_pr_push_target(None) == (None, None)
-        assert _resolve_pr_push_target("") == (None, None)
-        assert _resolve_pr_push_target("unknown") == (None, None)
+        assert _resolve_pr_push_target(None) == (None, None, False)
+        assert _resolve_pr_push_target("") == (None, None, False)
+        assert _resolve_pr_push_target("unknown") == (None, None, False)
 
     def test_returns_none_without_gh_token(self, monkeypatch):
         monkeypatch.delenv("GH_TOKEN", raising=False)
-        assert _resolve_pr_push_target("42") == (None, None)
+        assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_none_on_command_failure(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="")
-            assert _resolve_pr_push_target("42") == (None, None)
+            assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_none_on_null_owner_repo(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="my-branch\tnull\tnull")
-            assert _resolve_pr_push_target("42") == (None, None)
+            mock_run.return_value = MagicMock(returncode=0, stdout="my-branch\tnull\tnull\tOPEN")
+            assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_none_on_null_branch(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="null\towner\trepo")
-            assert _resolve_pr_push_target("42") == (None, None)
+            mock_run.return_value = MagicMock(returncode=0, stdout="null\towner\trepo\tOPEN")
+            assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_none_on_invalid_owner(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="branch\tbad owner!\trepo")
-            assert _resolve_pr_push_target("42") == (None, None)
+            mock_run.return_value = MagicMock(returncode=0, stdout="branch\tbad owner!\trepo\tOPEN")
+            assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_none_on_malformed_output(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="only-one-field")
-            assert _resolve_pr_push_target("42") == (None, None)
+            assert _resolve_pr_push_target("42") == (None, None, False)
 
     def test_returns_branch_and_url_on_success(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="fix/my-branch\tfork-owner\tmy-project"
+                returncode=0, stdout="fix/my-branch\tfork-owner\tmy-project\tOPEN"
             )
-            branch, url = _resolve_pr_push_target("42")
+            branch, url, merged = _resolve_pr_push_target("42")
         assert branch == "fix/my-branch"
         assert url == "https://github.com/fork-owner/my-project.git"
+        assert merged is False
+
+    def test_detects_merged_pr(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="fix/my-branch\towner\trepo\tMERGED"
+            )
+            branch, url, merged = _resolve_pr_push_target("42")
+        assert branch == "fix/my-branch"
+        assert merged is True
 
     def test_branch_with_slashes(self, monkeypatch):
         monkeypatch.setenv("GH_TOKEN", "test")
         with patch("suggest_docs.run_command_safe") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="feature/deep/nested/branch\towner\trepo"
+                returncode=0, stdout="feature/deep/nested/branch\towner\trepo\tOPEN"
             )
-            branch, _ = _resolve_pr_push_target("42")
+            branch, _, merged = _resolve_pr_push_target("42")
         assert branch == "feature/deep/nested/branch"
+        assert merged is False
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 # Stub openai before any script imports config
 sys.modules.setdefault("openai", MagicMock())
 
-from suggest_docs import _normalize_github_url, _resolve_pr_push_target, main
+from suggest_docs import (
+    _normalize_github_url,
+    _push_docs_pr_for_merged,
+    _resolve_pr_push_target,
+    main,
+)
 
 # ── _normalize_github_url ────────────────────────────────────────────────────
 
@@ -116,6 +121,79 @@ class TestResolvePrPushTarget:
             branch, _, merged = _resolve_pr_push_target("42")
         assert branch == "feature/deep/nested/branch"
         assert merged is False
+
+
+# ── _push_docs_pr_for_merged ─────────────────────────────────────────────────
+
+
+class TestPushDocsPrForMerged:
+    def _mock_run(
+        self, push_ok=True, pr_list_stdout="[]", create_stdout="https://github.com/org/repo/pull/99"
+    ):
+        calls = []
+
+        def side_effect(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock(returncode=0, stdout="")
+            if "fetch" in cmd:
+                pass
+            elif "checkout" in cmd:
+                pass
+            elif "push" in cmd:
+                if not push_ok:
+                    import subprocess
+
+                    raise subprocess.CalledProcessError(1, cmd)
+            elif cmd[:3] == ["gh", "pr", "list"]:
+                result.stdout = pr_list_stdout
+            elif cmd[:3] == ["gh", "pr", "create"]:
+                result.stdout = create_stdout
+            elif cmd[:3] == ["gh", "pr", "edit"]:
+                pass
+            return result
+
+        return side_effect, calls
+
+    def test_creates_new_pr_returns_url(self):
+        side_effect, calls = self._mock_run()
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            url = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert url == "https://github.com/org/repo/pull/99"
+        assert any("pr" in str(c) and "create" in str(c) for c in calls)
+
+    def test_updates_existing_pr_returns_url(self):
+        pr_list = '[{"number": 55, "url": "https://github.com/org/repo/pull/55"}]'
+        side_effect, calls = self._mock_run(pr_list_stdout=pr_list)
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            url = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert url == "https://github.com/org/repo/pull/55"
+        assert any("edit" in str(c) for c in calls)
+
+    def test_push_failure_returns_none(self):
+        side_effect, _ = self._mock_run(push_ok=False)
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            result = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert result is None
+
+    def test_existing_pr_bad_json_returns_empty(self):
+        side_effect, _ = self._mock_run(pr_list_stdout="not-json")
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            url = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert url == ""
+
+    def test_create_empty_stdout_returns_empty(self):
+        side_effect, _ = self._mock_run(create_stdout="")
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            url = _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        assert url == ""
+
+    def test_fetches_branch_before_push(self):
+        side_effect, calls = self._mock_run()
+        with patch("suggest_docs.run_command_safe", side_effect=side_effect):
+            _push_docs_pr_for_merged("42", ["docs/guide.md"], "token")
+        fetch_idx = next(i for i, c in enumerate(calls) if "fetch" in str(c))
+        push_idx = next(i for i, c in enumerate(calls) if "push" in str(c))
+        assert fetch_idx < push_idx
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `[update-docs]` runs on a merged PR, the original branch is typically deleted and the push fails
- Instead of failing, detect the merged state and create a new docs PR against the base branch
- Uses a `docs/update-from-pr-{number}` branch to avoid name collisions
- If a docs PR already exists for the same source PR, the branch is updated instead of creating a duplicate
- The confirmation comment on the source PR includes a link to the new docs PR

## How it works

`_resolve_pr_push_target()` now also returns the PR's merge state via `gh pr view --json state`. The push logic has three paths:

| PR state | Action |
|----------|--------|
| Open (same-repo) | Push directly to PR branch |
| Open (fork) | Re-point origin to fork, push to fork branch |
| Merged | Create `docs/update-from-pr-{N}` branch, push to upstream, open docs PR |

## Test plan

- [x] 24 tests pass (1 new: `test_detects_merged_pr`)
- [x] Lint and format clean
- [x] Open PR path unchanged
- [x] Fork PR path unchanged
- [x] Separate-repo path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)