### PR TITLE
feat: teach AI to write new capability docs, not just annotate

### DIFF
--- a/src/generation.py
+++ b/src/generation.py
@@ -149,6 +149,7 @@ def generate_updates_parallel(
     user_instructions="",
     file_instructions=None,
     style_guidelines="",
+    pr_description="",
 ):
     """
     Generate documentation updates in parallel.
@@ -160,6 +161,7 @@ def generate_updates_parallel(
         user_instructions: Optional global reviewer instructions to pass to the AI
         file_instructions: Optional dict mapping filenames to per-file instructions
         style_guidelines: Optional persistent style guidelines from config file
+        pr_description: Optional PR title and body for context
 
     Returns:
         list: List of (file_path, original_content, updated_content) tuples
@@ -180,6 +182,7 @@ def generate_updates_parallel(
             user_instructions=user_instructions,
             file_instructions=file_instructions,
             style_guidelines=style_guidelines,
+            pr_description=pr_description,
         )
 
         if updated.strip() == "NO_UPDATE_NEEDED":
@@ -229,6 +232,7 @@ def ask_ai_for_updated_content(
     user_instructions="",
     file_instructions=None,
     style_guidelines="",
+    pr_description="",
 ):
     is_markdown = file_path.endswith(".md")
     is_asciidoc = file_path.endswith(".adoc")
@@ -299,6 +303,14 @@ FORMATTING REQUIREMENTS:
 - Use consistent indentation and spacing
 """
 
+    pr_context = ""
+    if pr_description:
+        pr_context = f"""
+PR description (for context only — the diff above is the source of truth):
+{pr_description}
+Use this to understand the intent behind the change, but only document what is actually present in the diff.
+"""
+
     prompt_template = f"""
 You are updating documentation based on a code diff. Be thorough.
 
@@ -307,7 +319,7 @@ You are updating documentation based on a code diff. Be thorough.
 
 Git diff:
 {{DIFF_PLACEHOLDER}}
-
+{pr_context}
 Current documentation file `{file_path}`:
 --------------------
 {current_content}
@@ -331,14 +343,15 @@ If the diff removes an error, rejection, or "not supported" message,
 the feature that was blocked is now available. Document the new
 capability, not just any constraints around it.
 
-Follow the patterns in the existing documentation.
+When documenting a new capability, write its documentation as if it
+didn't exist before — because it didn't. Add it where it belongs in
+the file, following the same structure as existing capabilities.
 
 WHAT YOU CAN ADD:
-- Only content that directly reflects what was added/changed in the diff
+- Content that documents what was added/changed in the diff
 
 WHAT YOU MUST NOT ADD:
-- New sections or paragraphs not justified by the diff
-- Unrelated content not connected to the diff
+- Content unrelated to the diff
 - Restructured or rewritten content
 
 Return ONLY:

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -58,6 +58,32 @@ from security_utils import run_command_safe, setup_git_credentials
 _GITHUB_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 
 
+def _get_pr_description(pr_number):
+    """Fetch the PR title and body for context."""
+    if not pr_number or pr_number == "unknown":
+        return ""
+    gh_token = os.environ.get("GH_TOKEN")
+    if not gh_token:
+        return ""
+    result = run_command_safe(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "title,body",
+            "--jq",
+            '.title + "\\n" + .body',
+        ],
+        check=False,
+        env={**os.environ, "GH_TOKEN": gh_token},
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return ""
+
+
 def _normalize_github_url(url):
     """Normalize a GitHub URL to https://github.com/owner/repo for comparison."""
     url = url.strip().rstrip("/")
@@ -335,8 +361,9 @@ def main():
         print(f"Source repository: {commit_info['repo_url']}")
         print(f"Latest commit: {commit_info['short_hash']}")
 
-    # Get PR number for posting comments
+    # Get PR number and description for context
     pr_number = os.environ.get("PR_NUMBER", "unknown")
+    pr_description = _get_pr_description(pr_number)
 
     # === FEATURE ANALYSIS (before docs env setup, since it uses MCP not docs repo) ===
     if feature_mode and feature_issue_key:
@@ -499,6 +526,7 @@ def main():
             user_instructions=user_instructions,
             file_instructions=file_instructions,
             style_guidelines=style_guidelines,
+            pr_description=pr_description,
         )
 
         for file_path, _current, updated in files_with_content:
@@ -522,6 +550,7 @@ def main():
                 user_instructions=user_instructions,
                 file_instructions=file_instructions,
                 style_guidelines=style_guidelines,
+                pr_description=pr_description,
             )
 
             if updated.strip() == "NO_UPDATE_NEEDED":

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -7,11 +7,49 @@ from unittest.mock import MagicMock, patch
 sys.modules.setdefault("openai", MagicMock())
 
 from suggest_docs import (
+    _get_pr_description,
     _normalize_github_url,
     _push_docs_pr_for_merged,
     _resolve_pr_push_target,
     main,
 )
+
+# ── _get_pr_description ──────────────────────────────────────────────────────
+
+
+class TestGetPrDescription:
+    def test_returns_empty_without_pr_number(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        assert _get_pr_description(None) == ""
+        assert _get_pr_description("") == ""
+        assert _get_pr_description("unknown") == ""
+
+    def test_returns_empty_without_gh_token(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        assert _get_pr_description("42") == ""
+
+    def test_returns_title_and_body(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="Add new feature\nThis PR adds a new capability."
+            )
+            result = _get_pr_description("42")
+        assert "Add new feature" in result
+        assert "new capability" in result
+
+    def test_returns_empty_on_command_failure(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert _get_pr_description("42") == ""
+
+    def test_returns_empty_on_empty_output(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "test")
+        with patch("suggest_docs.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="   ")
+            assert _get_pr_description("42") == ""
+
 
 # ── _normalize_github_url ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Three changes to improve AI content generation quality:

### 1. Prompt improvements
- **"write its documentation as if it didn't exist before"** — shifts the AI from annotation mode (adding a note) to authoring mode (writing proper documentation for new capabilities)
- **"documents" instead of "directly reflects"** — allows the AI to write examples and explanations, not just mirror code changes
- **Removed "New sections or paragraphs not justified by the diff"** — this was blocking the AI from adding examples and structured content

### 2. PR description as context
- Fetches the PR title and body via `gh pr view` and injects it into the generation prompt
- Framed as supplementary context: "Use this to understand the intent behind the change, but only document what is actually present in the diff"
- The diff remains the source of truth — the description helps the AI understand WHY the change was made

### 3. Remaining safeguards
- Decision logic (3-step gate) still filters whether to update
- "Content unrelated to the diff" and "Restructured or rewritten content" constraints still apply
- "Following the same structure as existing capabilities" provides implicit proportionality

## Test plan

- [x] 44 tests pass (generation + suggest_docs)
- [x] Lint and format clean

Generated with [Claude Code](https://claude.com/claude-code)