### PR TITLE
fix: load style config from base branch, not PR branch

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,12 +9,11 @@ or a user-specified STYLE_CONFIG_PATH.
 
 import os
 import re
-from pathlib import Path
 
 import openai
 from openai import OpenAI
 
-from security_utils import sanitize_output, validate_file_path
+from security_utils import run_command_safe, sanitize_output
 
 
 def get_client():
@@ -150,51 +149,47 @@ _AUTO_DETECT_PATHS = [
 _ALLOWED_STYLE_EXTENSIONS = (".md",)
 
 
-def load_style_config(config_path=None):
-    """Load documentation style guidelines from a config file."""
-    if not config_path:
-        config_path = os.environ.get("STYLE_CONFIG_PATH", "")
+def load_style_config_from_branch():
+    """Load style config from the base branch via git show.
 
-    if config_path:
-        if not validate_file_path(config_path):
-            print(
-                f"Warning: Style config path rejected by security check: '{config_path}', skipping"
-            )
-            return ""
-        if not config_path.endswith(_ALLOWED_STYLE_EXTENSIONS):
-            print(f"Warning: Style config must be a .md file, got '{config_path}', skipping")
-            return ""
-        config_file = Path(config_path)
-        if not config_file.is_file():
-            print(f"Warning: Style config not found at '{config_path}', skipping")
-            return ""
-    else:
-        config_file = None
-        for candidate in _AUTO_DETECT_PATHS:
-            p = Path(candidate)
-            if p.is_file() and validate_file_path(str(p)):
-                config_file = p
-                break
-        if config_file is None:
-            return ""
-
-    config_path_str = str(config_file)
-    print(f"Loading style config from: {config_path_str}")
-
+    Reads the style config directly from origin/{base_branch} so the
+    repo's current style rules always apply, regardless of when the
+    PR branch was created.
+    """
     try:
-        raw = config_file.read_text(encoding="utf-8").strip()
+        base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+        style_path = os.environ.get("STYLE_CONFIG_PATH", "")
+
+        paths = [style_path] if style_path else _AUTO_DETECT_PATHS
+
+        run_command_safe(["git", "fetch", "origin", base_branch], check=False)
+
+        for path in paths:
+            if not path or not path.endswith(_ALLOWED_STYLE_EXTENSIONS):
+                if path:
+                    print(f"Warning: Style config must be a .md file, got '{path}', skipping")
+                continue
+            if ".." in path.split("/") or path.startswith("/"):
+                print(f"Warning: Style config path rejected (traversal): '{path}', skipping")
+                continue
+            result = run_command_safe(
+                ["git", "show", f"origin/{base_branch}:{path}"],
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                print(
+                    f"Loaded style config from {base_branch}:{path}"
+                    f" ({len(result.stdout.strip()):,} chars)"
+                )
+                return result.stdout.strip()
+            if result.returncode == 0 and not result.stdout.strip():
+                print(f"Warning: Style config '{path}' on {base_branch} is empty, skipping")
+            elif style_path:
+                print(f"Warning: Style config '{path}' not found on {base_branch}")
     except Exception as e:
-        print(
-            f"Warning: Could not read style config '{config_path_str}': {sanitize_output(str(e))}"
-        )
-        return ""
+        print(f"Warning: Could not load style config from base branch: {sanitize_output(str(e))}")
 
-    if not raw:
-        print(f"Warning: Style config '{config_path_str}' is empty, skipping")
-        return ""
-
-    print(f"Loaded style config ({len(raw):,} chars)")
-    return raw
+    return ""
 
 
 def check_context_error(e):

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -32,7 +32,7 @@ from config import (
     get_client,
     get_max_context_chars,
     get_model_name,
-    load_style_config,
+    load_style_config_from_branch,
 )
 from discovery import (
     ask_ai_for_relevant_files,
@@ -243,8 +243,9 @@ def main():
     source = "MAX_CONTEXT_CHARS" if raw else "default"
     print(f"Context budget: {budget:,} chars (from {source})")
 
-    # Load persistent style guidelines (if configured)
-    style_guidelines = load_style_config()
+    # Load persistent style guidelines from the base branch so the AI always
+    # uses the repo's current style config, even if the PR branch predates it.
+    style_guidelines = load_style_config_from_branch()
 
     # Handle --build-index mode
     if args.build_index:

--- a/tests/test_style_config.py
+++ b/tests/test_style_config.py
@@ -1,70 +1,8 @@
-"""Tests for persistent style configuration and output format validation."""
+"""Tests for output format validation and code fence stripping."""
 
-import os
 from unittest.mock import MagicMock, patch
 
-from config import load_style_config
 from generation import strip_code_fences, validate_format
-
-# =============================================================================
-# load_style_config tests
-# =============================================================================
-
-
-class TestLoadStyleConfig:
-    def test_loads_from_explicit_path(self, tmp_path):
-        style_file = tmp_path / "my-style.md"
-        style_file.write_text("Use active voice\nKeep paragraphs short")
-        os.chdir(tmp_path)
-        result = load_style_config(config_path=str(style_file))
-        assert "active voice" in result
-
-    def test_returns_empty_when_file_missing(self, tmp_path):
-        os.chdir(tmp_path)
-        result = load_style_config(config_path="nonexistent.md")
-        assert result == ""
-
-    def test_auto_detects_default_path(self, tmp_path):
-        code_to_docs_dir = tmp_path / ".code-to-docs"
-        code_to_docs_dir.mkdir()
-        style_file = code_to_docs_dir / "style.md"
-        style_file.write_text("# Style Rules\nUse dashes for lists")
-        os.chdir(tmp_path)
-        result = load_style_config()
-        assert "dashes" in result
-
-    def test_returns_empty_when_no_auto_detect(self, tmp_path):
-        os.chdir(tmp_path)
-        result = load_style_config()
-        assert result == ""
-
-    def test_env_var_override(self, tmp_path, monkeypatch):
-        style_file = tmp_path / "custom-style.md"
-        style_file.write_text("Custom style from env var")
-        os.chdir(tmp_path)
-        monkeypatch.setenv("STYLE_CONFIG_PATH", str(style_file))
-        result = load_style_config()
-        assert "Custom style" in result
-
-    def test_rejects_non_md_extension(self, tmp_path):
-        style_file = tmp_path / "style.txt"
-        style_file.write_text("Some style rules")
-        os.chdir(tmp_path)
-        result = load_style_config(config_path=str(style_file))
-        assert result == ""
-
-    def test_rejects_path_traversal(self, tmp_path):
-        os.chdir(tmp_path)
-        result = load_style_config(config_path="../../../etc/passwd.md")
-        assert result == ""
-
-    def test_returns_empty_for_empty_file(self, tmp_path):
-        style_file = tmp_path / "empty.md"
-        style_file.write_text("")
-        os.chdir(tmp_path)
-        result = load_style_config(config_path=str(style_file))
-        assert result == ""
-
 
 # =============================================================================
 # strip_code_fences tests

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 # Stub openai before any script imports config
 sys.modules.setdefault("openai", MagicMock())
 
+# ── load_style_config_from_branch ───────────────────────────────────────────
+from config import load_style_config_from_branch
 from suggest_docs import (
     _get_pr_description,
     _normalize_github_url,
@@ -13,6 +15,71 @@ from suggest_docs import (
     _resolve_pr_push_target,
     main,
 )
+
+
+class TestLoadStyleConfigFromBranch:
+    def test_loads_style_from_main(self):
+        with patch("config.run_command_safe") as mock_run:
+            fetch_result = MagicMock(returncode=0, stdout="")
+            show_result = MagicMock(
+                returncode=0, stdout="# Style Rules\nAlways include examples.\n"
+            )
+            mock_run.side_effect = [fetch_result, show_result]
+            result = load_style_config_from_branch()
+        assert "Always include examples" in result
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "fetch", "origin", "main"] == calls[0]
+        assert "git" == calls[1][0] and "show" == calls[1][1]
+
+    def test_returns_empty_when_file_missing(self):
+        with patch("config.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert load_style_config_from_branch() == ""
+
+    def test_returns_empty_when_file_empty(self):
+        with patch("config.run_command_safe") as mock_run:
+            fetch_result = MagicMock(returncode=0, stdout="")
+            show_result = MagicMock(returncode=0, stdout="   ")
+            mock_run.side_effect = [fetch_result, show_result]
+            assert load_style_config_from_branch() == ""
+
+    def test_uses_custom_path(self, monkeypatch):
+        monkeypatch.setenv("STYLE_CONFIG_PATH", "custom/style.md")
+        with patch("config.run_command_safe") as mock_run:
+            fetch_result = MagicMock(returncode=0, stdout="")
+            show_result = MagicMock(returncode=0, stdout="Custom rules")
+            mock_run.side_effect = [fetch_result, show_result]
+            result = load_style_config_from_branch()
+        assert result == "Custom rules"
+        show_cmd = mock_run.call_args_list[1].args[0]
+        assert "custom/style.md" in show_cmd[2]
+
+    def test_uses_custom_base_branch(self, monkeypatch):
+        monkeypatch.setenv("DOCS_BASE_BRANCH", "develop")
+        with patch("config.run_command_safe") as mock_run:
+            fetch_result = MagicMock(returncode=0, stdout="")
+            show_result = MagicMock(returncode=0, stdout="Rules")
+            mock_run.side_effect = [fetch_result, show_result]
+            load_style_config_from_branch()
+        fetch_cmd = mock_run.call_args_list[0].args[0]
+        assert ["git", "fetch", "origin", "develop"] == fetch_cmd
+        show_cmd = mock_run.call_args_list[1].args[0]
+        assert "origin/develop:" in show_cmd[2]
+
+    def test_rejects_non_md_path(self, monkeypatch):
+        monkeypatch.setenv("STYLE_CONFIG_PATH", "style.txt")
+        with patch("config.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="should not be read")
+            assert load_style_config_from_branch() == ""
+        assert mock_run.call_count == 1
+
+    def test_rejects_path_traversal(self, monkeypatch):
+        monkeypatch.setenv("STYLE_CONFIG_PATH", "../../../etc/passwd.md")
+        with patch("config.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="should not be read")
+            assert load_style_config_from_branch() == ""
+        assert mock_run.call_count == 1
+
 
 # ── _get_pr_description ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The style config (`.code-to-docs/style.md`) was loaded from the PR head commit. If the style config was added to main after the PR branch was created, it wasn't found — the log showed "Style config not found" even though the file existed on main.

Now uses `git show origin/{base_branch}:{path}` to read the style config directly from the base branch. The repo's current style rules always apply, regardless of when the PR branch was created.

## Works for all cases

- **Merged PRs**: Style loaded from `origin/main` before branch switch
- **Open PRs**: Style loaded from `origin/main` regardless of PR branch state
- **Separate-repo**: Same — reads from the code repo's base branch
- **No style.md**: Returns empty string, base prompt applies
- **Empty style.md**: Returns empty string, base prompt applies
- **Custom path** (`STYLE_CONFIG_PATH`): Supported
- **Custom base branch** (`DOCS_BASE_BRANCH`): Supported

## Test plan

- [x] 42 tests pass (6 new for `_load_style_from_base_branch`)
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)