### PR TITLE
docs: align README update-docs example with default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Comment on any Pull Request:
 You can guide how the AI generates doc updates by adding instructions in your `[update-docs]` comment — global on the first line, per-file on subsequent lines:
 
 ```
-[update-docs] keep changes minimal
+[update-docs] focus on the new CLI flags
 config-ref.rst: only update the CLI usage example
 ```
 
@@ -46,7 +46,7 @@ The action auto-detects this file. To use a custom path instead, set the `style-
 - Use present tense
 ```
 
-Per-comment instructions (`[update-docs] keep changes minimal`) continue to work alongside the persistent config, appearing as additional guidance after the style guidelines. If per-comment or per-file instructions contradict the style guidelines, the reviewer's instructions take precedence.
+Per-comment instructions (`[update-docs] focus on the new CLI flags`) continue to work alongside the persistent config, appearing as additional guidance after the style guidelines. If per-comment or per-file instructions contradict the style guidelines, the reviewer's instructions take precedence.
 
 ## How It Works
 


### PR DESCRIPTION
Fixes #39\n\n### Summary\nReplace the misleading keep changes minimal example in both README locations with a scoped instruction that demonstrates how to guide the comprehensive-by-default update-docs behavior.\n\n### Validation\n- git diff --check passed\n- Static assertion confirms the old text is gone and the replacement appears in both documented locations\n- pytest -q could not collect because the local environment is missing the openai dependency