### PR TITLE
fix: improve index fetch diagnostics and use targeted ls-tree

### DIFF
--- a/src/comments.py
+++ b/src/comments.py
@@ -28,7 +28,7 @@ def get_docs_file_url(file_path, commit_info=None):
         GitHub URL to the file, or None if URL cannot be constructed
     """
     docs_subfolder = os.environ.get("DOCS_SUBFOLDER")
-    base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+    base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
 
     if docs_subfolder and commit_info and "repo_url" in commit_info:
         # Same repo scenario: use source repo URL + subfolder

--- a/src/config.py
+++ b/src/config.py
@@ -157,7 +157,7 @@ def load_style_config_from_branch():
     PR branch was created.
     """
     try:
-        base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+        base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
         style_path = os.environ.get("STYLE_CONFIG_PATH", "")
 
         paths = [style_path] if style_path else _AUTO_DETECT_PATHS

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -1096,28 +1096,45 @@ def fetch_indexes_from_main():
             print(f"Checking for cached indexes/summaries on {base_branch} branch...")
 
             # Fetch the base branch
-            run_command_safe(["git", "fetch", "origin", base_branch], check=False)
+            fetch_result = run_command_safe(
+                ["git", "fetch", "origin", base_branch], check=False
+            )
+            if fetch_result.returncode != 0:
+                print(
+                    f"Could not fetch {base_branch} branch "
+                    f"(exit {fetch_result.returncode}): "
+                    f"{sanitize_output(fetch_result.stderr or '').strip()}"
+                )
+                return False
 
-            # Check if index directory exists on the base branch
+            # Check if the index directory exists on the base branch
             check_result = run_command_safe(
-                ["git", "ls-tree", "-r", f"origin/{base_branch}", "--name-only"], check=False
+                ["git", "ls-tree", f"origin/{base_branch}", "--", index_relative_path],
+                check=False,
             )
 
-            if check_result.returncode != 0 or index_relative_path not in check_result.stdout:
-                print(f"No cached indexes/summaries found on {base_branch} branch")
+            if check_result.returncode != 0 or not check_result.stdout.strip():
+                print(
+                    f"No cached indexes/summaries found on {base_branch} branch "
+                    f"(looked for {index_relative_path})"
+                )
                 return False
 
             # Checkout the index directory from main (includes summaries)
             print(f"Fetching indexes and summaries from {base_branch}...")
             checkout_result = run_command_safe(
-                ["git", "checkout", f"origin/{base_branch}", "--", index_relative_path], check=False
+                ["git", "checkout", f"origin/{base_branch}", "--", index_relative_path],
+                check=False,
             )
 
             if checkout_result.returncode == 0:
                 print(f"✅ Fetched indexes and summaries from {base_branch}")
                 return True
             else:
-                print(f"Could not fetch indexes/summaries from {base_branch}")
+                print(
+                    f"Could not checkout indexes from {base_branch}: "
+                    f"{sanitize_output(checkout_result.stderr or '').strip()}"
+                )
                 return False
 
     except Exception as e:

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -681,7 +681,7 @@ def commit_indexes_to_repo(content_type="indexes"):
                 print(f"No {content_type} changes to commit")
                 return False
 
-            base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+            base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
             gh_token = os.environ.get("GH_TOKEN")
             if not gh_token:
                 print("Warning: GH_TOKEN not set, cannot create index PR")
@@ -1025,7 +1025,7 @@ def checkout_docs_from_base_branch():
     if not docs_subfolder:
         return False
 
-    base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+    base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
     docs_root = get_docs_root().resolve()
     repo_root = docs_root.parent
 
@@ -1091,7 +1091,7 @@ def fetch_indexes_from_main():
 
     try:
         with working_directory(target_dir):
-            base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+            base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
 
             print(f"Checking for cached indexes/summaries on {base_branch} branch...")
 

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -1096,9 +1096,7 @@ def fetch_indexes_from_main():
             print(f"Checking for cached indexes/summaries on {base_branch} branch...")
 
             # Fetch the base branch
-            fetch_result = run_command_safe(
-                ["git", "fetch", "origin", base_branch], check=False
-            )
+            fetch_result = run_command_safe(["git", "fetch", "origin", base_branch], check=False)
             if fetch_result.returncode != 0:
                 print(
                     f"Could not fetch {base_branch} branch "

--- a/src/github_ops.py
+++ b/src/github_ops.py
@@ -233,7 +233,7 @@ def push_and_open_pr(modified_files, commit_info=None):
                     "--body",
                     pr_body,
                     "--base",
-                    os.environ.get("DOCS_BASE_BRANCH", "main"),
+                    os.environ.get("DOCS_BASE_BRANCH") or "main",
                     "--head",
                     branch_name,
                 ],

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -146,7 +146,7 @@ def _push_docs_pr_for_merged(pr_number, docs_branch, docs_files, gh_token):
     Returns the docs PR URL on success (empty string if URL could not
     be extracted), or None on failure.
     """
-    base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+    base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
     try:
         run_command_safe(
             ["git", "push", "--set-upstream", "origin", docs_branch, "--force-with-lease"],
@@ -448,7 +448,7 @@ def main():
         pr_branch_info = _resolve_pr_push_target(pr_number)
         _, _, pr_merged = pr_branch_info
         if pr_merged:
-            base_branch = os.environ.get("DOCS_BASE_BRANCH", "main")
+            base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
             docs_branch = f"docs/update-from-pr-{pr_number}"
             try:
                 os.chdir("..")

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -373,6 +373,20 @@ class TestCheckoutDocsFromBaseBranch:
         assert ["git", "fetch", "origin", "develop"] in calls
         assert ["git", "checkout", "origin/develop", "--", "docs/new.md"] in calls
 
+    def test_empty_base_branch_falls_back_to_main(self, monkeypatch, tmp_path):
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
+        monkeypatch.setenv("DOCS_BASE_BRANCH", "")
+        monkeypatch.chdir(docs_dir)
+
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_ls_tree(["docs/new.md"])
+            checkout_docs_from_base_branch()
+
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "fetch", "origin", "main"] in calls
+
     def test_defaults_to_main_branch(self, monkeypatch, tmp_path):
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir()

--- a/tests/test_suggest_docs.py
+++ b/tests/test_suggest_docs.py
@@ -66,6 +66,16 @@ class TestLoadStyleConfigFromBranch:
         show_cmd = mock_run.call_args_list[1].args[0]
         assert "origin/develop:" in show_cmd[2]
 
+    def test_empty_base_branch_falls_back_to_main(self, monkeypatch):
+        monkeypatch.setenv("DOCS_BASE_BRANCH", "")
+        with patch("config.run_command_safe") as mock_run:
+            fetch_result = MagicMock(returncode=0, stdout="")
+            show_result = MagicMock(returncode=0, stdout="Rules")
+            mock_run.side_effect = [fetch_result, show_result]
+            load_style_config_from_branch()
+        fetch_cmd = mock_run.call_args_list[0].args[0]
+        assert ["git", "fetch", "origin", "main"] == fetch_cmd
+
     def test_rejects_non_md_path(self, monkeypatch):
         monkeypatch.setenv("STYLE_CONFIG_PATH", "style.txt")
         with patch("config.run_command_safe") as mock_run:


### PR DESCRIPTION
## Summary
- `fetch_indexes_from_main()` was failing silently — `git fetch` and `ls-tree` failures were swallowed by `check=False`, producing only "No cached indexes found" with no actionable detail
- Replaced `git ls-tree -r` (lists every file in the repo) + substring search with targeted `git ls-tree origin/main -- <path>` for the specific index directory
- Added diagnostic logging: fetch failures now show exit code + sanitized stderr, and the exact path being checked is logged so mismatches are immediately obvious

## Test plan
- [x] All 382 existing tests pass
- [ ] Verify diagnostic output on a repo where indexes exist on main but were previously not fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)