### PR TITLE
fix: skip fork push and show suggested changes in PR comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: write  # Required to push doc updates to PR branches
   issues: write
   pull-requests: write
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jobs:
         id: pr_info
         if: github.event.issue.pull_request
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
           echo "Extracting PR information for PR #$PR_NUMBER"
@@ -111,7 +111,7 @@ jobs:
           repository: ${{ steps.pr_info.outputs.head_repo || github.repository }}
           ref: ${{ steps.pr_info.outputs.head_ref || github.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Documentation Assistant
         uses: redhat-community-ai-tools/code-to-docs@main
@@ -120,7 +120,7 @@ jobs:
           model-api-key: ${{ secrets.MODEL_API_KEY }}
           model-name: ${{ secrets.MODEL_NAME }}
           docs-repo-url: ${{ secrets.DOCS_REPO_URL }}
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.issue.number }}
           pr-base: origin/${{ steps.pr_info.outputs.base_ref || 'main' }}
           pr-head-sha: ${{ steps.pr_info.outputs.head_ref }}
@@ -145,7 +145,7 @@ Add these in **Settings → Secrets → Actions**:
 | `MODEL_API_KEY` | API key for the model endpoint (leave empty if not required) |
 | `MODEL_NAME` | Model name to use (e.g., `meta-llama/Llama-3.1-8B-Instruct`, `gemini-2.0-flash`) |
 | `DOCS_REPO_URL` | Docs repository URL (e.g., `https://github.com/org/docs`) |
-| `GH_PAT` | GitHub token with `repo` + `pull_requests:write` permissions. Used for creating docs PRs, posting review comments, and submitting index update PRs |
+| `GITHUB_TOKEN` | Built-in GitHub Actions token — no setup needed. Works for same-repo setups (`docs-subfolder`): creating docs PRs, posting review comments, and submitting index update PRs. For fork PRs, doc changes are shown as suggestions in the PR comment instead of pushed directly. **For separate docs repos** (`docs-repo-url` pointing to a different repo), use a PAT with `repo` scope instead. |
 | `DOCS_SUBFOLDER` | _(Optional)_ Docs subfolder path (e.g., `docs`) |
 | `DOCS_BASE_BRANCH` | _(Optional)_ Base branch for docs PRs (default: `main`) |
 | `JIRA_URL` | _(Optional, for `[review-feature]`)_ Jira instance URL (e.g., `https://your-company.atlassian.net`) |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jobs:
           model-api-key: ${{ secrets.MODEL_API_KEY }}
           model-name: ${{ secrets.MODEL_NAME }}
           docs-repo-url: ${{ secrets.DOCS_REPO_URL }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}  # For separate docs repos, use a PAT: ${{ secrets.GH_PAT }}
           pr-number: ${{ github.event.issue.number }}
           pr-base: origin/${{ steps.pr_info.outputs.base_ref || 'main' }}
           pr-head-sha: ${{ steps.pr_info.outputs.head_ref }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.issue.pull_request && 
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       (contains(github.event.comment.body, '[review-docs]') ||
        contains(github.event.comment.body, '[update-docs]') ||
        contains(github.event.comment.body, '[review-feature]'))
@@ -145,7 +146,7 @@ Add these in **Settings → Secrets → Actions**:
 | `MODEL_API_KEY` | API key for the model endpoint (leave empty if not required) |
 | `MODEL_NAME` | Model name to use (e.g., `meta-llama/Llama-3.1-8B-Instruct`, `gemini-2.0-flash`) |
 | `DOCS_REPO_URL` | Docs repository URL (e.g., `https://github.com/org/docs`) |
-| `GITHUB_TOKEN` | Built-in GitHub Actions token — no setup needed. Works for same-repo setups (`docs-subfolder`): creating docs PRs, posting review comments, and submitting index update PRs. For fork PRs, doc changes are shown as suggestions in the PR comment instead of pushed directly. **For separate docs repos** (`docs-repo-url` pointing to a different repo), use a PAT with `repo` scope instead. |
+| `GH_PAT` | _(Optional)_ GitHub PAT with `repo` scope. Only needed for **separate docs repos** (`docs-repo-url` pointing to a different repo). For same-repo setups, the built-in `GITHUB_TOKEN` works — no PAT required. |
 | `DOCS_SUBFOLDER` | _(Optional)_ Docs subfolder path (e.g., `docs`) |
 | `DOCS_BASE_BRANCH` | _(Optional)_ Base branch for docs PRs (default: `main`) |
 | `JIRA_URL` | _(Optional, for `[review-feature]`)_ Jira instance URL (e.g., `https://your-company.atlassian.net`) |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -283,7 +283,7 @@
         <span class="yaml-key">id:</span> <span class="yaml-value">pr_info</span>
         <span class="yaml-key">if:</span> <span class="yaml-value">github.event.issue.pull_request</span>
         <span class="yaml-key">env:</span>
-          <span class="yaml-key">GH_TOKEN:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">GH_TOKEN:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
         <span class="yaml-key">run:</span> <span class="yaml-value">|
           PR_NUMBER=${{ github.event.issue.number }}
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
@@ -301,7 +301,7 @@
           <span class="yaml-key">repository:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_repo || github.repository }}</span>
           <span class="yaml-key">ref:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_ref || github.ref }}</span>
           <span class="yaml-key">fetch-depth:</span> <span class="yaml-value">0</span>
-          <span class="yaml-key">token:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">token:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
 
       - <span class="yaml-key">name:</span> <span class="yaml-value">Documentation Assistant</span>
         <span class="yaml-key">uses:</span> <span class="yaml-value">redhat-community-ai-tools/code-to-docs@main</span>
@@ -310,7 +310,7 @@
           <span class="yaml-key">model-api-key:</span> <span class="yaml-value">${{ secrets.MODEL_API_KEY }}</span>
           <span class="yaml-key">model-name:</span> <span class="yaml-value">${{ secrets.MODEL_NAME }}</span>
           <span class="yaml-key">docs-repo-url:</span> <span class="yaml-value">${{ secrets.DOCS_REPO_URL }}</span>
-          <span class="yaml-key">github-token:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">github-token:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
           <span class="yaml-key">pr-number:</span> <span class="yaml-value">${{ github.event.issue.number }}</span>
           <span class="yaml-key">pr-base:</span> <span class="yaml-value">origin/${{ steps.pr_info.outputs.base_ref || 'main' }}</span>
           <span class="yaml-key">pr-head-sha:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_ref }}</span>
@@ -352,9 +352,9 @@
                                 <td>Docs repository URL (e.g., https://github.com/org/docs)</td>
                             </tr>
                             <tr>
-                                <td><span class="secret-name">GH_PAT</span></td>
-                                <td><span class="secret-dots">&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;</span></td>
-                                <td>GitHub token with repo + pull_requests:write permissions</td>
+                                <td><span class="secret-name">GITHUB_TOKEN</span></td>
+                                <td style="color:var(--gh-text-secondary);font-style:italic;font-size:12px;">Built-in</td>
+                                <td>Built-in GitHub Actions token (no setup needed for same-repo)</td>
                             </tr>
                             <tr>
                                 <td><span class="secret-name">DOCS_SUBFOLDER</span></td>

--- a/demo/review-feature.html
+++ b/demo/review-feature.html
@@ -368,7 +368,7 @@
         <span class="yaml-key">id:</span> <span class="yaml-value">pr_info</span>
         <span class="yaml-key">if:</span> <span class="yaml-value">github.event.issue.pull_request</span>
         <span class="yaml-key">env:</span>
-          <span class="yaml-key">GH_TOKEN:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">GH_TOKEN:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
         <span class="yaml-key">run:</span> <span class="yaml-value">|
           PR_NUMBER=${{ github.event.issue.number }}
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
@@ -386,7 +386,7 @@
           <span class="yaml-key">repository:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_repo || github.repository }}</span>
           <span class="yaml-key">ref:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_ref || github.ref }}</span>
           <span class="yaml-key">fetch-depth:</span> <span class="yaml-value">0</span>
-          <span class="yaml-key">token:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">token:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
 
       - <span class="yaml-key">name:</span> <span class="yaml-value">Documentation Assistant</span>
         <span class="yaml-key">uses:</span> <span class="yaml-value">redhat-community-ai-tools/code-to-docs@main</span>
@@ -395,7 +395,7 @@
           <span class="yaml-key">model-api-key:</span> <span class="yaml-value">${{ secrets.MODEL_API_KEY }}</span>
           <span class="yaml-key">model-name:</span> <span class="yaml-value">${{ secrets.MODEL_NAME }}</span>
           <span class="yaml-key">docs-repo-url:</span> <span class="yaml-value">${{ secrets.DOCS_REPO_URL }}</span>
-          <span class="yaml-key">github-token:</span> <span class="yaml-value">${{ secrets.GH_PAT }}</span>
+          <span class="yaml-key">github-token:</span> <span class="yaml-value">${{ secrets.GITHUB_TOKEN }}</span>
           <span class="yaml-key">pr-number:</span> <span class="yaml-value">${{ github.event.issue.number }}</span>
           <span class="yaml-key">pr-base:</span> <span class="yaml-value">origin/${{ steps.pr_info.outputs.base_ref || 'main' }}</span>
           <span class="yaml-key">pr-head-sha:</span> <span class="yaml-value">${{ steps.pr_info.outputs.head_ref }}</span>
@@ -442,9 +442,9 @@
                                 <td>Docs repository URL (e.g., https://github.com/org/docs)</td>
                             </tr>
                             <tr>
-                                <td><span class="secret-name">GH_PAT</span></td>
-                                <td><span class="secret-dots">&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;</span></td>
-                                <td>GitHub token with repo + pull_requests:write permissions</td>
+                                <td><span class="secret-name">GITHUB_TOKEN</span></td>
+                                <td style="color:var(--gh-text-secondary);font-style:italic;font-size:12px;">Built-in</td>
+                                <td>Built-in GitHub Actions token (no setup needed for same-repo)</td>
                             </tr>
                             <tr>
                                 <td><span class="secret-name">DOCS_SUBFOLDER</span></td>

--- a/src/github_ops.py
+++ b/src/github_ops.py
@@ -179,7 +179,7 @@ def push_and_open_pr(modified_files, commit_info=None):
         if not gh_token:
             raise ValueError("GH_TOKEN environment variable not set")
 
-        # Clear GitHub Actions default authentication that interferes with our PAT
+        # Clear GitHub Actions default authentication that interferes with GH_TOKEN
         run_command_safe(
             ["git", "config", "--unset-all", "http.https://github.com/.extraheader"],
             check=False,

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -619,6 +619,7 @@ def main():
                         )
                         if not pr_branch:
                             print("Warning: Could not resolve PR branch name, cannot push")
+                            push_failed = True
                         else:
                             origin_url = run_command_safe(
                                 ["git", "config", "--get", "remote.origin.url"], check=False

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -53,7 +53,7 @@ from jira_integration import (
     format_feature_review_section,
     parse_feature_command,
 )
-from security_utils import run_command_safe, setup_git_credentials
+from security_utils import run_command_safe
 
 _GITHUB_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 
@@ -440,6 +440,8 @@ def main():
     # and file writes land on the correct branch.
     docs_subfolder = os.environ.get("DOCS_SUBFOLDER")
     pr_merged = False
+    is_fork = False
+    push_failed = False
     docs_pr_url = None
     docs_pr_failed = False
     docs_branch = None
@@ -632,42 +634,13 @@ def main():
                                 != _normalize_github_url(current_origin)
                             )
 
-                            try:
-                                if is_fork:
-                                    if not setup_git_credentials(gh_token, pr_repo_url):
-                                        print(
-                                            "Warning: Failed to configure credentials for fork, cannot push"
-                                        )
-                                    else:
-                                        run_command_safe(
-                                            ["git", "remote", "set-url", "origin", pr_repo_url],
-                                            check=True,
-                                        )
-                                        try:
-                                            run_command_safe(
-                                                [
-                                                    "git",
-                                                    "push",
-                                                    "origin",
-                                                    f"HEAD:refs/heads/{pr_branch}",
-                                                ],
-                                                check=True,
-                                            )
-                                            print(
-                                                f"✅ Pushed doc updates to PR branch ({pr_branch})"
-                                            )
-                                        finally:
-                                            run_command_safe(
-                                                [
-                                                    "git",
-                                                    "remote",
-                                                    "set-url",
-                                                    "origin",
-                                                    current_origin,
-                                                ],
-                                                check=False,
-                                            )
-                                else:
+                            if is_fork:
+                                print(
+                                    "Fork PR detected — cannot push directly. "
+                                    "Suggested changes will be shown in the PR comment."
+                                )
+                            else:
+                                try:
                                     run_command_safe(
                                         [
                                             "git",
@@ -678,11 +651,12 @@ def main():
                                         check=True,
                                     )
                                     print(f"✅ Pushed doc updates to PR branch ({pr_branch})")
-                            except subprocess.CalledProcessError as e:
-                                print(
-                                    f"Warning: Failed to push doc updates: {e}. "
-                                    "Check that GH_PAT has repo scope and the PR allows maintainer pushes."
-                                )
+                                except subprocess.CalledProcessError as e:
+                                    print(
+                                        f"Warning: Failed to push doc updates: {e}. "
+                                        "Check that GH_TOKEN has contents:write permission."
+                                    )
+                                    push_failed = True
                 else:
                     print("Separate-repo scenario: creating PR...")
                     push_and_open_pr(modified_files, commit_info)
@@ -690,18 +664,26 @@ def main():
             # Post confirmation comment for [update-docs]
             if update_mode and modified_files and not args.dry_run:
                 confirm_parts = []
-                confirm_parts.append("## 📚 Documentation Update")
+                if is_fork:
+                    confirm_parts.append("## 📝 Suggested Documentation Changes")
+                else:
+                    confirm_parts.append("## 📚 Documentation Update")
                 confirm_parts.append("")
                 if modified_files:
-                    if previous_review and previous_review["review_found"]:
+                    if is_fork:
+                        confirm_parts.append(
+                            f"Suggested updates for **{len(modified_files)} file(s)**:"
+                        )
+                    elif previous_review and previous_review["review_found"]:
                         confirm_parts.append(
                             f"Updated **{len(modified_files)} file(s)** based on your review selections:"
                         )
                     else:
                         confirm_parts.append(f"Updated **{len(modified_files)} file(s)**:")
                     confirm_parts.append("")
+                    marker = "📄" if is_fork else "✅"
                     for f in modified_files:
-                        confirm_parts.append(f"- ✅ `{f}`")
+                        confirm_parts.append(f"- {marker} `{f}`")
                 if previous_review and previous_review.get("rejected_files"):
                     confirm_parts.append("")
                     confirm_parts.append(
@@ -746,6 +728,18 @@ def main():
                         confirm_parts.append(f"A docs PR has been created: {docs_pr_url}")
                     elif docs_subfolder and pr_merged:
                         confirm_parts.append("A docs PR has been created with these changes.")
+                    elif docs_subfolder and is_fork:
+                        confirm_parts.append(
+                            "This is a fork PR, so I can't push changes directly. "
+                            "The suggested changes are shown above for you to apply.\n\n"
+                            "Once this PR is merged, comment `[update-docs]` again "
+                            "and I'll create a docs PR with these updates."
+                        )
+                    elif docs_subfolder and push_failed:
+                        confirm_parts.append(
+                            "Failed to push doc updates to this PR. "
+                            "The suggested changes are shown above for manual application."
+                        )
                     elif docs_subfolder:
                         confirm_parts.append("Doc updates have been committed to this PR.")
                     else:

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -665,13 +665,14 @@ def main():
             # Post confirmation comment for [update-docs]
             if update_mode and modified_files and not args.dry_run:
                 confirm_parts = []
-                if is_fork:
+                show_as_suggestion = is_fork or push_failed
+                if show_as_suggestion:
                     confirm_parts.append("## 📝 Suggested Documentation Changes")
                 else:
                     confirm_parts.append("## 📚 Documentation Update")
                 confirm_parts.append("")
                 if modified_files:
-                    if is_fork:
+                    if show_as_suggestion:
                         confirm_parts.append(
                             f"Suggested updates for **{len(modified_files)} file(s)**:"
                         )
@@ -682,7 +683,7 @@ def main():
                     else:
                         confirm_parts.append(f"Updated **{len(modified_files)} file(s)**:")
                     confirm_parts.append("")
-                    marker = "📄" if is_fork else "✅"
+                    marker = "📄" if show_as_suggestion else "✅"
                     for f in modified_files:
                         confirm_parts.append(f"- {marker} `{f}`")
                 if previous_review and previous_review.get("rejected_files"):


### PR DESCRIPTION
## Summary
- For fork PRs, `[update-docs]` can't push doc changes directly (`GITHUB_TOKEN` doesn't have access to fork repos). Previously the tool attempted to push and failed silently
- Now detects fork PRs and posts suggested changes as diffs in the PR comment, with guidance to re-run `[update-docs]` after merge to create a docs PR
- Fixes same-repo push failures silently reporting "Doc updates have been committed to this PR" when the push actually failed

## Changes
- Remove fork push logic (credential setup, remote URL swapping, push attempt)
- Add fork-specific PR comment: "Suggested Documentation Changes" header, neutral 📄 markers, and explanation to re-run after merge
- Add `push_failed` flag so same-repo push failures show correct message
- Remove unused `setup_git_credentials` import

## Test plan
- [x] All 384 existing tests pass
- [ ] Verify on a fork PR: comment shows suggested changes with diffs and fork explanation
- [ ] Verify on a same-repo PR: behavior unchanged (pushes directly to PR branch)
- [ ] Verify on a merged PR: behavior unchanged (creates docs PR against main)
- [ ] Verify same-repo push failure shows correct "Failed to push" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)