### PR TITLE
fix: compare index hashes against base branch, not PR branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Requires `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN` secrets. Optionally u
 Semantic indexes speed up doc file discovery by caching LLM-generated summaries of documentation folders. Key functions:
 
 - `fetch_indexes_from_main()` — fetches cached indexes from the base branch
-- `folder_needs_reindex()` — compares SHA256 doc hashes to detect changes
+- `folder_needs_reindex()` — compares SHA256 doc hashes against `origin/main` (via `get_folder_doc_hashes_from_ref`) to detect changes, with fallback to disk hashes
 - `build_all_indexes()` / `update_indexes_if_needed()` — regenerate via LLM only for changed folders
 - `commit_indexes_to_repo()` — pushes indexes to a persistent `code-to-docs/update-indexes` branch and creates/updates a PR
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,15 @@ jobs:
           ref: ${{ steps.pr_info.outputs.head_ref || github.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
+      - name: Rebind Origin to Main Repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://github.com/${{ github.repository }}.git"
+          git config --local http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+
       - name: Documentation Assistant
         uses: redhat-community-ai-tools/code-to-docs@main
         with:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jobs:
         run: |
           git remote set-url origin "https://github.com/${{ github.repository }}.git"
           git config --local http.https://github.com/.extraheader \
-            "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+            "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64 -w 0)"
 
       - name: Documentation Assistant
         uses: redhat-community-ai-tools/code-to-docs@main

--- a/src/comments.py
+++ b/src/comments.py
@@ -440,7 +440,7 @@ def post_review_comment(
             "  - **Global** (first line): <code>&#91;update-docs] keep changes minimal, don't add new sections</code>"
         )
         comment_parts.append(
-            "  - **Per-file** (next lines): `config-ref.rst: only update the CLI usage example`"
+            "  - **Per-file** (next lines): <code>config-ref.rst: only update the CLI usage example</code>"
         )
         comment_parts.append("")
         comment_parts.append("*Powered by code-to-docs AI* \u2728")

--- a/src/comments.py
+++ b/src/comments.py
@@ -427,15 +427,17 @@ def post_review_comment(
         comment_parts.append("- **Uncheck** any files above that you don't want updated")
         if not include_full_content:
             comment_parts.append(
-                "- When ready, comment `&#91;update-docs]` to generate a PR with only the checked files"
+                "- When ready, comment <code>&#91;update-docs]</code> to generate a PR with only the checked files"
             )
         else:
             comment_parts.append(
-                "- When ready, comment `&#91;update-docs]` to create a PR with only the checked files"
+                "- When ready, comment <code>&#91;update-docs]</code> to create a PR with only the checked files"
             )
-        comment_parts.append("- You can add instructions in your `&#91;update-docs]` comment:")
         comment_parts.append(
-            "  - **Global** (first line): `[\u200bupdate-docs] keep changes minimal, don't add new sections`"
+            "- You can add instructions in your <code>&#91;update-docs]</code> comment:"
+        )
+        comment_parts.append(
+            "  - **Global** (first line): <code>&#91;update-docs] keep changes minimal, don't add new sections</code>"
         )
         comment_parts.append(
             "  - **Per-file** (next lines): `config-ref.rst: only update the CLI usage example`"

--- a/src/comments.py
+++ b/src/comments.py
@@ -427,13 +427,13 @@ def post_review_comment(
         comment_parts.append("- **Uncheck** any files above that you don't want updated")
         if not include_full_content:
             comment_parts.append(
-                "- When ready, comment `[\u200bupdate-docs]` to generate a PR with only the checked files"
+                "- When ready, comment `&#91;update-docs]` to generate a PR with only the checked files"
             )
         else:
             comment_parts.append(
-                "- When ready, comment `[\u200bupdate-docs]` to create a PR with only the checked files"
+                "- When ready, comment `&#91;update-docs]` to create a PR with only the checked files"
             )
-        comment_parts.append("- You can add instructions in your `[\u200bupdate-docs]` comment:")
+        comment_parts.append("- You can add instructions in your `&#91;update-docs]` comment:")
         comment_parts.append(
             "  - **Global** (first line): `[\u200bupdate-docs] keep changes minimal, don't add new sections`"
         )

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -413,9 +413,67 @@ def _batch_docs_by_budget(docs_content, budget, prompt_overhead):
     return batches
 
 
+def _get_docs_content_from_ref(folder):
+    """
+    Read doc file content from the base branch ref.
+
+    Returns a list of {"path": str, "content": str} dicts, or None
+    if the ref is unavailable.
+    """
+    ref = _get_base_branch_ref()
+    docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "")
+
+    if folder == ROOT_LEVEL_FOLDER:
+        search_path = docs_subfolder or "."
+    else:
+        search_path = f"{docs_subfolder}/{folder}" if docs_subfolder else folder
+
+    result = run_command_safe(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", search_path],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    doc_extensions = (".md", ".rst", ".adoc")
+    docs_content = []
+
+    for file_path in result.stdout.strip().split("\n"):
+        if not any(file_path.endswith(ext) for ext in doc_extensions):
+            continue
+
+        rel_to_docs = file_path
+        if docs_subfolder and file_path.startswith(docs_subfolder + "/"):
+            rel_to_docs = file_path[len(docs_subfolder) + 1 :]
+
+        parts = Path(rel_to_docs).parent.parts
+        if any(p.startswith(".") or p.startswith("_") for p in parts):
+            continue
+
+        if folder == ROOT_LEVEL_FOLDER:
+            if len(Path(rel_to_docs).parts) > 1:
+                continue
+        else:
+            if str(Path(rel_to_docs).parent) != folder:
+                continue
+
+        content_result = run_command_safe(
+            ["git", "show", f"{ref}:{file_path}"],
+            check=False,
+        )
+        if content_result.returncode == 0 and content_result.stdout:
+            docs_content.append({"path": rel_to_docs, "content": content_result.stdout})
+
+    return docs_content if docs_content else None
+
+
 def build_index_for_folder(folder, client=None):
     """
     Build a semantic index for a documentation folder.
+
+    Reads doc content from origin/main when available so that indexes
+    always reflect the base branch, even when running on a fork PR.
+    Falls back to reading from disk if the ref is unavailable.
 
     If all files fit within the context budget at full content, processes in a
     single API call. Otherwise, batches files into groups that fit the budget,
@@ -430,18 +488,32 @@ def build_index_for_folder(folder, client=None):
     if client is None:
         client = get_client()
 
-    docs = get_docs_in_folder(folder)
-    if not docs:
-        return None
+    # Read content from origin/main so indexes always reflect the base branch.
+    # If the folder doesn't exist on main (e.g., added by a fork PR), skip it —
+    # it will be indexed after the PR merges.
+    # Falls back to disk only when git ref is entirely unavailable (e.g., local runs).
+    ref = _get_base_branch_ref()
+    ref_available = (
+        run_command_safe(["git", "rev-parse", "--verify", ref], check=False).returncode == 0
+    )
 
-    # Gather content from all docs in the folder
-    docs_content = []
-    for doc in docs:
-        try:
-            content = doc.read_text(encoding="utf-8")
-            docs_content.append({"path": str(doc), "content": content})
-        except Exception as e:
-            print(f"Warning: Could not read {doc}: {sanitize_output(str(e))}")
+    if ref_available:
+        docs_content = _get_docs_content_from_ref(folder)
+        if docs_content is None:
+            print(f"Skipping {folder} (not found on {ref})")
+            return None
+    else:
+        docs = get_docs_in_folder(folder)
+        if not docs:
+            return None
+
+        docs_content = []
+        for doc in docs:
+            try:
+                content = doc.read_text(encoding="utf-8")
+                docs_content.append({"path": str(doc), "content": content})
+            except Exception as e:
+                print(f"Warning: Could not read {doc}: {sanitize_output(str(e))}")
 
     if not docs_content:
         return None

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -202,7 +202,7 @@ def save_manifest(manifest, docs_root=None):
 
 def get_folder_doc_hashes(folder, docs_root=None):
     """
-    Get hashes of all docs in a folder.
+    Get hashes of all docs in a folder from disk.
 
     Args:
         folder: Folder name relative to docs root
@@ -222,9 +222,73 @@ def get_folder_doc_hashes(folder, docs_root=None):
     return hashes
 
 
+def _get_base_branch_ref():
+    """Get the git ref for the base branch (e.g., origin/main)."""
+    base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
+    return f"origin/{base_branch}"
+
+
+def get_folder_doc_hashes_from_ref(folder, docs_root=None):
+    """
+    Get hashes of docs in a folder from the base branch git ref.
+
+    Uses git to read file content from origin/main instead of disk,
+    so that index hash comparisons are always against the base branch
+    even when running on a fork PR branch.
+
+    Returns None if the ref is not available (falls back to disk hashes).
+    """
+    if docs_root is None:
+        docs_root = get_docs_root()
+
+    ref = _get_base_branch_ref()
+    docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "")
+
+    if folder == ROOT_LEVEL_FOLDER:
+        search_path = docs_subfolder or "."
+    else:
+        search_path = f"{docs_subfolder}/{folder}" if docs_subfolder else folder
+
+    result = run_command_safe(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", search_path],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    doc_extensions = (".md", ".rst", ".adoc")
+    hashes = {}
+
+    for file_path in result.stdout.strip().split("\n"):
+        if not any(file_path.endswith(ext) for ext in doc_extensions):
+            continue
+
+        rel_to_docs = file_path
+        if docs_subfolder and file_path.startswith(docs_subfolder + "/"):
+            rel_to_docs = file_path[len(docs_subfolder) + 1:]
+
+        parts = Path(rel_to_docs).parent.parts
+        if any(p.startswith(".") or p.startswith("_") for p in parts):
+            continue
+
+        # Read binary content from the ref for consistent hashing
+        content_result = subprocess.run(
+            ["git", "cat-file", "blob", f"{ref}:{file_path}"],
+            capture_output=True,
+        )
+        if content_result.returncode == 0 and content_result.stdout:
+            file_hash = hashlib.sha256(content_result.stdout).hexdigest()
+            hashes[rel_to_docs] = file_hash
+
+    return hashes if hashes else None
+
+
 def folder_needs_reindex(folder, manifest, docs_root=None):
     """
     Check if a folder needs its index regenerated.
+
+    Compares stored hashes against the base branch (origin/main) to ensure
+    consistent results regardless of which branch the tool runs on.
 
     Args:
         folder: Folder name
@@ -239,7 +303,8 @@ def folder_needs_reindex(folder, manifest, docs_root=None):
         return True
 
     stored_hashes = manifest["folders"][folder].get("doc_hashes", {})
-    current_hashes = get_folder_doc_hashes(folder, docs_root)
+    ref_hashes = get_folder_doc_hashes_from_ref(folder, docs_root)
+    current_hashes = ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder, docs_root)
 
     return stored_hashes != current_hashes
 
@@ -591,9 +656,10 @@ def build_all_indexes(force=False):
                 index_content = future.result()
                 if index_content:
                     save_index(folder, index_content)
+                    ref_hashes = get_folder_doc_hashes_from_ref(folder)
                     manifest["folders"][folder] = {
                         "built": datetime.now().isoformat(),
-                        "doc_hashes": get_folder_doc_hashes(folder),
+                        "doc_hashes": ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder),
                     }
                     results[folder] = "success"
                     print(f"✅ Built index for {folder}")
@@ -628,9 +694,10 @@ def update_indexes_if_needed():
             index_content = build_index_for_folder_with_retry(folder, client)
             if index_content:
                 save_index(folder, index_content)
+                ref_hashes = get_folder_doc_hashes_from_ref(folder)
                 manifest["folders"][folder] = {
                     "built": datetime.now().isoformat(),
-                    "doc_hashes": get_folder_doc_hashes(folder),
+                    "doc_hashes": ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder),
                 }
                 updated_folders.append(folder)
                 print(f"✅ Updated index for {folder}")

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -236,7 +236,12 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
     so that index hash comparisons are always against the base branch
     even when running on a fork PR branch.
 
-    Returns None if the ref is not available (falls back to disk hashes).
+    Args:
+        folder: Folder name relative to docs root, or ROOT_LEVEL_FOLDER
+        docs_root: Optional root path for docs. If None, uses get_docs_root()
+
+    Returns:
+        dict: File path to SHA256 hash mapping, or None if ref is unavailable
     """
     if docs_root is None:
         docs_root = get_docs_root()
@@ -271,14 +276,25 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
         if any(p.startswith(".") or p.startswith("_") for p in parts):
             continue
 
-        # Read binary content from the ref for consistent hashing
-        content_result = subprocess.run(
-            ["git", "cat-file", "blob", f"{ref}:{file_path}"],
-            capture_output=True,
-        )
-        if content_result.returncode == 0 and content_result.stdout:
-            file_hash = hashlib.sha256(content_result.stdout).hexdigest()
-            hashes[rel_to_docs] = file_hash
+        # Match disk-based get_docs_in_folder behavior: non-recursive
+        if folder == ROOT_LEVEL_FOLDER:
+            if len(Path(rel_to_docs).parts) > 1:
+                continue
+        else:
+            if str(Path(rel_to_docs).parent) != folder:
+                continue
+
+        # Binary subprocess for consistent hashing with hash_file()
+        try:
+            content_result = subprocess.run(
+                ["git", "cat-file", "blob", f"{ref}:{file_path}"],
+                capture_output=True,
+            )
+            if content_result.returncode == 0 and content_result.stdout:
+                file_hash = hashlib.sha256(content_result.stdout).hexdigest()
+                hashes[rel_to_docs] = file_hash
+        except Exception as e:
+            print(f"Warning: Could not read {file_path} from {ref}: {sanitize_output(str(e))}")
 
     return hashes if hashes else None
 

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -265,7 +265,7 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
 
         rel_to_docs = file_path
         if docs_subfolder and file_path.startswith(docs_subfolder + "/"):
-            rel_to_docs = file_path[len(docs_subfolder) + 1:]
+            rel_to_docs = file_path[len(docs_subfolder) + 1 :]
 
         parts = Path(rel_to_docs).parent.parts
         if any(p.startswith(".") or p.startswith("_") for p in parts):
@@ -304,7 +304,9 @@ def folder_needs_reindex(folder, manifest, docs_root=None):
 
     stored_hashes = manifest["folders"][folder].get("doc_hashes", {})
     ref_hashes = get_folder_doc_hashes_from_ref(folder, docs_root)
-    current_hashes = ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder, docs_root)
+    current_hashes = (
+        ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder, docs_root)
+    )
 
     return stored_hashes != current_hashes
 
@@ -659,7 +661,9 @@ def build_all_indexes(force=False):
                     ref_hashes = get_folder_doc_hashes_from_ref(folder)
                     manifest["folders"][folder] = {
                         "built": datetime.now().isoformat(),
-                        "doc_hashes": ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder),
+                        "doc_hashes": ref_hashes
+                        if ref_hashes is not None
+                        else get_folder_doc_hashes(folder),
                     }
                     results[folder] = "success"
                     print(f"✅ Built index for {folder}")
@@ -697,7 +701,9 @@ def update_indexes_if_needed():
                 ref_hashes = get_folder_doc_hashes_from_ref(folder)
                 manifest["folders"][folder] = {
                     "built": datetime.now().isoformat(),
-                    "doc_hashes": ref_hashes if ref_hashes is not None else get_folder_doc_hashes(folder),
+                    "doc_hashes": ref_hashes
+                    if ref_hashes is not None
+                    else get_folder_doc_hashes(folder),
                 }
                 updated_folders.append(folder)
                 print(f"✅ Updated index for {folder}")

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -241,7 +241,8 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
         docs_root: Optional root path for docs. If None, uses get_docs_root()
 
     Returns:
-        dict: File path to SHA256 hash mapping, or None if ref is unavailable
+        dict: File path to SHA256 hash mapping. None if ref is unavailable,
+              empty dict if folder has no doc files on the ref.
     """
     if docs_root is None:
         docs_root = get_docs_root()
@@ -258,8 +259,10 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
         ["git", "ls-tree", "-r", "--name-only", ref, "--", search_path],
         check=False,
     )
-    if result.returncode != 0 or not result.stdout.strip():
+    if result.returncode != 0:
         return None
+    if not result.stdout.strip():
+        return {}
 
     doc_extensions = (".md", ".rst", ".adoc")
     hashes = {}
@@ -284,19 +287,15 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
             if str(Path(rel_to_docs).parent) != folder:
                 continue
 
-        # Binary subprocess for consistent hashing with hash_file()
-        try:
-            content_result = subprocess.run(
-                ["git", "cat-file", "blob", f"{ref}:{file_path}"],
-                capture_output=True,
-            )
-            if content_result.returncode == 0 and content_result.stdout:
-                file_hash = hashlib.sha256(content_result.stdout).hexdigest()
-                hashes[rel_to_docs] = file_hash
-        except Exception as e:
-            print(f"Warning: Could not read {file_path} from {ref}: {sanitize_output(str(e))}")
+        content_result = run_command_safe(
+            ["git", "show", f"{ref}:{file_path}"],
+            check=False,
+        )
+        if content_result.returncode == 0 and content_result.stdout:
+            file_hash = hashlib.sha256(content_result.stdout.encode("utf-8")).hexdigest()
+            hashes[rel_to_docs] = file_hash
 
-    return hashes if hashes else None
+    return hashes
 
 
 def folder_needs_reindex(folder, manifest, docs_root=None):
@@ -417,8 +416,8 @@ def _get_docs_content_from_ref(folder):
     """
     Read doc file content from the base branch ref.
 
-    Returns a list of {"path": str, "content": str} dicts, or None
-    if the ref is unavailable.
+    Returns a list of {"path": str, "content": str} dicts. None if ref is
+    unavailable, empty list if folder has no doc files on the ref.
     """
     ref = _get_base_branch_ref()
     docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "")
@@ -432,8 +431,10 @@ def _get_docs_content_from_ref(folder):
         ["git", "ls-tree", "-r", "--name-only", ref, "--", search_path],
         check=False,
     )
-    if result.returncode != 0 or not result.stdout.strip():
+    if result.returncode != 0:
         return None
+    if not result.stdout.strip():
+        return []
 
     doc_extensions = (".md", ".rst", ".adoc")
     docs_content = []
@@ -464,7 +465,7 @@ def _get_docs_content_from_ref(folder):
         if content_result.returncode == 0 and content_result.stdout:
             docs_content.append({"path": rel_to_docs, "content": content_result.stdout})
 
-    return docs_content if docs_content else None
+    return docs_content
 
 
 def build_index_for_folder(folder, client=None):
@@ -499,7 +500,7 @@ def build_index_for_folder(folder, client=None):
 
     if ref_available:
         docs_content = _get_docs_content_from_ref(folder)
-        if docs_content is None:
+        if not docs_content:
             print(f"Skipping {folder} (not found on {ref})")
             return None
     else:

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -287,13 +287,19 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
             if str(Path(rel_to_docs).parent) != folder:
                 continue
 
-        content_result = run_command_safe(
-            ["git", "show", f"{ref}:{file_path}"],
-            check=False,
-        )
-        if content_result.returncode == 0 and content_result.stdout:
-            file_hash = hashlib.sha256(content_result.stdout.encode("utf-8")).hexdigest()
-            hashes[rel_to_docs] = file_hash
+        # Binary subprocess for byte-identical hashing with hash_file().
+        # run_command_safe uses text=True which applies universal newline
+        # translation (\r\n → \n), breaking hash consistency for CRLF files.
+        try:
+            content_result = subprocess.run(
+                ["git", "cat-file", "blob", f"{ref}:{file_path}"],
+                capture_output=True,
+            )
+            if content_result.returncode == 0 and content_result.stdout:
+                file_hash = hashlib.sha256(content_result.stdout).hexdigest()
+                hashes[rel_to_docs] = file_hash
+        except Exception as e:
+            print(f"Warning: Could not read {file_path} from {ref}: {sanitize_output(str(e))}")
 
     return hashes
 

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -293,7 +293,8 @@ def get_folder_doc_hashes_from_ref(folder, docs_root=None):
         try:
             content_result = subprocess.run(
                 ["git", "cat-file", "blob", f"{ref}:{file_path}"],
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
             )
             if content_result.returncode == 0 and content_result.stdout:
                 file_hash = hashlib.sha256(content_result.stdout).hexdigest()

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -507,8 +507,11 @@ def build_index_for_folder(folder, client=None):
 
     if ref_available:
         docs_content = _get_docs_content_from_ref(folder)
-        if not docs_content:
+        if docs_content is None:
             print(f"Skipping {folder} (not found on {ref})")
+            return None
+        if not docs_content:
+            print(f"Skipping {folder} (no doc files on {ref})")
             return None
     else:
         docs = get_docs_in_folder(folder)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -446,7 +446,7 @@ def main():
     docs_pr_failed = False
     docs_branch = None
     pr_branch_info = None
-    if update_mode and docs_subfolder:
+    if (update_mode or review_mode) and docs_subfolder:
         pr_branch_info = _resolve_pr_push_target(pr_number)
         _, _, pr_merged = pr_branch_info
         if pr_merged:

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -53,7 +53,7 @@ from jira_integration import (
     format_feature_review_section,
     parse_feature_command,
 )
-from security_utils import run_command_safe
+from security_utils import run_command_safe, sanitize_output
 
 _GITHUB_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 
@@ -435,9 +435,10 @@ def main():
         print("Failed to set up docs environment")
         return
 
-    # For merged PRs in same-repo mode, switch to a clean branch from main
-    # BEFORE discovery/generation so the pipeline runs against main's docs
-    # and file writes land on the correct branch.
+    # For merged PRs in same-repo mode, switch to main's docs content
+    # BEFORE discovery/generation so the pipeline runs against main's docs.
+    # update_mode creates a branch (needs to push); review_mode does a
+    # read-only checkout of the docs subfolder.
     docs_subfolder = os.environ.get("DOCS_SUBFOLDER")
     pr_merged = False
     is_fork = False
@@ -451,18 +452,26 @@ def main():
         _, _, pr_merged = pr_branch_info
         if pr_merged:
             base_branch = os.environ.get("DOCS_BASE_BRANCH") or "main"
-            docs_branch = f"docs/update-from-pr-{pr_number}"
             try:
                 os.chdir("..")
                 run_command_safe(["git", "fetch", "origin", base_branch], check=False)
-                run_command_safe(["git", "fetch", "origin", docs_branch], check=False)
-                run_command_safe(
-                    ["git", "checkout", "-B", docs_branch, f"origin/{base_branch}"], check=True
-                )
+                if update_mode:
+                    docs_branch = f"docs/update-from-pr-{pr_number}"
+                    run_command_safe(["git", "fetch", "origin", docs_branch], check=False)
+                    run_command_safe(
+                        ["git", "checkout", "-B", docs_branch, f"origin/{base_branch}"],
+                        check=True,
+                    )
+                    print(f"Switched to {docs_branch} (based on {base_branch}) for merged PR")
+                else:
+                    run_command_safe(
+                        ["git", "checkout", f"origin/{base_branch}", "--", docs_subfolder],
+                        check=True,
+                    )
+                    print(f"Checked out {docs_subfolder} from {base_branch} for merged PR review")
                 os.chdir(docs_subfolder)
-                print(f"Switched to {docs_branch} (based on {base_branch}) for merged PR")
             except (subprocess.CalledProcessError, OSError) as e:
-                print(f"Warning: Failed to create docs branch from {base_branch}: {e}")
+                print(f"Warning: Failed to checkout docs from {base_branch}: {sanitize_output(str(e))}")
                 pr_merged = False
                 try:
                     os.chdir(docs_subfolder)

--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -471,7 +471,9 @@ def main():
                     print(f"Checked out {docs_subfolder} from {base_branch} for merged PR review")
                 os.chdir(docs_subfolder)
             except (subprocess.CalledProcessError, OSError) as e:
-                print(f"Warning: Failed to checkout docs from {base_branch}: {sanitize_output(str(e))}")
+                print(
+                    f"Warning: Failed to checkout docs from {base_branch}: {sanitize_output(str(e))}"
+                )
                 pr_merged = False
                 try:
                     os.chdir(docs_subfolder)

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -285,27 +285,18 @@ class TestFolderNeedsReindex:
 
 
 class TestGetFolderDocHashesFromRef:
-    @staticmethod
-    def _mock_run_calls(ls_output, file_content):
-        """Return a side_effect function for run_command_safe that handles ls-tree + git show."""
-        call_count = [0]
-
-        def side_effect(cmd, **kwargs):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return MagicMock(returncode=0, stdout=ls_output)
-            return MagicMock(returncode=0, stdout=file_content)
-
-        return side_effect
-
     def test_returns_hashes_from_git_ref(self, monkeypatch):
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "guides/setup.md\nguides/intro.rst\nguides/.hidden/skip.md\n"
-        file_content = "doc content"
-        expected_hash = hashlib.sha256(file_content.encode("utf-8")).hexdigest()
+        file_content = b"doc content"
+        expected_hash = hashlib.sha256(file_content).hexdigest()
 
-        with patch("doc_index.run_command_safe") as mock_run:
-            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
             result = get_folder_doc_hashes_from_ref("guides")
 
         assert result is not None
@@ -334,10 +325,14 @@ class TestGetFolderDocHashesFromRef:
     def test_handles_docs_subfolder(self, monkeypatch):
         monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
         ls_output = "docs/commands/export.md\n"
-        file_content = "export docs"
+        file_content = b"export docs"
 
-        with patch("doc_index.run_command_safe") as mock_run:
-            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
             result = get_folder_doc_hashes_from_ref("commands")
 
         assert result is not None
@@ -347,24 +342,32 @@ class TestGetFolderDocHashesFromRef:
         monkeypatch.setenv("DOCS_BASE_BRANCH", "develop")
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
 
-        with patch("doc_index.run_command_safe") as mock_run:
-            mock_run.side_effect = self._mock_run_calls("guides/setup.md\n", "content")
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="guides/setup.md\n")
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=b"content")
             get_folder_doc_hashes_from_ref("guides")
 
         ls_call = mock_run.call_args_list[0].args[0]
         assert "origin/develop" in ls_call
-        show_call = mock_run.call_args_list[1].args[0]
-        assert "origin/develop:guides/setup.md" in show_call
+        cat_call = mock_subprocess.call_args_list[0].args[0]
+        assert "origin/develop:guides/setup.md" in cat_call
 
     def test_root_level_folder_excludes_subdirectory_files(self, monkeypatch):
         from doc_index import ROOT_LEVEL_FOLDER
 
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "README.md\noverview.rst\nguides/setup.md\ncommands/export.md\n"
-        file_content = "root content"
+        file_content = b"root content"
 
-        with patch("doc_index.run_command_safe") as mock_run:
-            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
             result = get_folder_doc_hashes_from_ref(ROOT_LEVEL_FOLDER)
 
         assert result is not None
@@ -376,10 +379,14 @@ class TestGetFolderDocHashesFromRef:
     def test_folder_excludes_files_from_other_folders(self, monkeypatch):
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "guides/setup.md\nguides/ops/health.md\ncommands/export.md\n"
-        file_content = "content"
+        file_content = b"content"
 
-        with patch("doc_index.run_command_safe") as mock_run:
-            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
             result = get_folder_doc_hashes_from_ref("guides")
 
         assert result is not None

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -350,6 +350,47 @@ class TestGetFolderDocHashesFromRef:
         cat_call = mock_subprocess.call_args_list[0].args[0]
         assert "origin/develop:guides/setup.md" in cat_call
 
+    def test_root_level_folder_excludes_subdirectory_files(self, monkeypatch):
+        from doc_index import ROOT_LEVEL_FOLDER
+
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+        ls_output = "README.md\noverview.rst\nguides/setup.md\ncommands/export.md\n"
+        file_content = b"root content"
+
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
+
+            result = get_folder_doc_hashes_from_ref(ROOT_LEVEL_FOLDER)
+
+        assert result is not None
+        assert "README.md" in result
+        assert "overview.rst" in result
+        assert "guides/setup.md" not in result
+        assert "commands/export.md" not in result
+
+    def test_folder_excludes_files_from_other_folders(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+        ls_output = "guides/setup.md\nguides/ops/health.md\ncommands/export.md\n"
+        file_content = b"content"
+
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
+
+            result = get_folder_doc_hashes_from_ref("guides")
+
+        assert result is not None
+        assert "guides/setup.md" in result
+        assert "guides/ops/health.md" not in result
+        assert "commands/export.md" not in result
+
 
 # ── Index save/load ──────────────────────────────────────────────────────────
 

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -9,6 +9,7 @@ import pytest
 from doc_index import (
     INDEX_DIR,
     SUMMARIES_DIR,
+    _get_docs_content_from_ref,
     checkout_docs_from_base_branch,
     folder_needs_reindex,
     get_doc_folders,
@@ -396,6 +397,86 @@ class TestGetFolderDocHashesFromRef:
         assert "guides/setup.md" in result
         assert "guides/ops/health.md" not in result
         assert "commands/export.md" not in result
+
+
+# ── _get_docs_content_from_ref ───────────────────────────────────────────────
+
+
+class TestGetDocsContentFromRef:
+    def test_returns_content_from_git_ref(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+        ls_output = "guides/setup.md\nguides/intro.rst\n"
+
+        call_count = [0]
+
+        def mock_run(cmd, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return MagicMock(returncode=0, stdout=ls_output)
+            return MagicMock(returncode=0, stdout="file content here")
+
+        with patch("doc_index.run_command_safe", side_effect=mock_run):
+            result = _get_docs_content_from_ref("guides")
+
+        assert len(result) == 2
+        assert result[0]["path"] == "guides/setup.md"
+        assert result[0]["content"] == "file content here"
+
+    def test_returns_none_when_git_fails(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = _get_docs_content_from_ref("guides")
+
+        assert result is None
+
+    def test_returns_empty_list_when_no_files(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = _get_docs_content_from_ref("guides")
+
+        assert result == []
+
+    def test_strips_docs_subfolder_from_path(self, monkeypatch):
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
+        ls_output = "docs/commands/export.md\n"
+
+        call_count = [0]
+
+        def mock_run(cmd, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return MagicMock(returncode=0, stdout=ls_output)
+            return MagicMock(returncode=0, stdout="export content")
+
+        with patch("doc_index.run_command_safe", side_effect=mock_run):
+            result = _get_docs_content_from_ref("commands")
+
+        assert len(result) == 1
+        assert result[0]["path"] == "commands/export.md"
+
+    def test_root_level_excludes_subdirectory_files(self, monkeypatch):
+        from doc_index import ROOT_LEVEL_FOLDER
+
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+        ls_output = "README.md\nguides/setup.md\n"
+
+        call_count = [0]
+
+        def mock_run(cmd, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return MagicMock(returncode=0, stdout=ls_output)
+            return MagicMock(returncode=0, stdout="root content")
+
+        with patch("doc_index.run_command_safe", side_effect=mock_run):
+            result = _get_docs_content_from_ref(ROOT_LEVEL_FOLDER)
+
+        assert len(result) == 1
+        assert result[0]["path"] == "README.md"
 
 
 # ── Index save/load ──────────────────────────────────────────────────────────

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -291,8 +291,10 @@ class TestGetFolderDocHashesFromRef:
         file_content = b"doc content"
         expected_hash = hashlib.sha256(file_content).hexdigest()
 
-        with patch("doc_index.run_command_safe") as mock_run, \
-             patch("doc_index.subprocess.run") as mock_subprocess:
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
             mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
             mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
 
@@ -317,8 +319,10 @@ class TestGetFolderDocHashesFromRef:
         ls_output = "docs/commands/export.md\n"
         file_content = b"export docs"
 
-        with patch("doc_index.run_command_safe") as mock_run, \
-             patch("doc_index.subprocess.run") as mock_subprocess:
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
             mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
             mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
 
@@ -332,8 +336,10 @@ class TestGetFolderDocHashesFromRef:
         monkeypatch.setenv("DOCS_BASE_BRANCH", "develop")
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
 
-        with patch("doc_index.run_command_safe") as mock_run, \
-             patch("doc_index.subprocess.run") as mock_subprocess:
+        with (
+            patch("doc_index.run_command_safe") as mock_run,
+            patch("doc_index.subprocess.run") as mock_subprocess,
+        ):
             mock_run.return_value = MagicMock(returncode=0, stdout="guides/setup.md\n")
             mock_subprocess.return_value = MagicMock(returncode=0, stdout=b"content")
 

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -285,19 +285,27 @@ class TestFolderNeedsReindex:
 
 
 class TestGetFolderDocHashesFromRef:
+    @staticmethod
+    def _mock_run_calls(ls_output, file_content):
+        """Return a side_effect function for run_command_safe that handles ls-tree + git show."""
+        call_count = [0]
+
+        def side_effect(cmd, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return MagicMock(returncode=0, stdout=ls_output)
+            return MagicMock(returncode=0, stdout=file_content)
+
+        return side_effect
+
     def test_returns_hashes_from_git_ref(self, monkeypatch):
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "guides/setup.md\nguides/intro.rst\nguides/.hidden/skip.md\n"
-        file_content = b"doc content"
-        expected_hash = hashlib.sha256(file_content).hexdigest()
+        file_content = "doc content"
+        expected_hash = hashlib.sha256(file_content.encode("utf-8")).hexdigest()
 
-        with (
-            patch("doc_index.run_command_safe") as mock_run,
-            patch("doc_index.subprocess.run") as mock_subprocess,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
-            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
-
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
             result = get_folder_doc_hashes_from_ref("guides")
 
         assert result is not None
@@ -314,56 +322,49 @@ class TestGetFolderDocHashesFromRef:
 
         assert result is None
 
+    def test_returns_empty_dict_when_no_files(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = get_folder_doc_hashes_from_ref("guides")
+
+        assert result == {}
+
     def test_handles_docs_subfolder(self, monkeypatch):
         monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
         ls_output = "docs/commands/export.md\n"
-        file_content = b"export docs"
+        file_content = "export docs"
 
-        with (
-            patch("doc_index.run_command_safe") as mock_run,
-            patch("doc_index.subprocess.run") as mock_subprocess,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
-            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
-
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
             result = get_folder_doc_hashes_from_ref("commands")
 
         assert result is not None
-        # Key should be relative to docs root (subfolder stripped)
         assert "commands/export.md" in result
 
     def test_uses_custom_base_branch(self, monkeypatch):
         monkeypatch.setenv("DOCS_BASE_BRANCH", "develop")
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
 
-        with (
-            patch("doc_index.run_command_safe") as mock_run,
-            patch("doc_index.subprocess.run") as mock_subprocess,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="guides/setup.md\n")
-            mock_subprocess.return_value = MagicMock(returncode=0, stdout=b"content")
-
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_run_calls("guides/setup.md\n", "content")
             get_folder_doc_hashes_from_ref("guides")
 
         ls_call = mock_run.call_args_list[0].args[0]
         assert "origin/develop" in ls_call
-        cat_call = mock_subprocess.call_args_list[0].args[0]
-        assert "origin/develop:guides/setup.md" in cat_call
+        show_call = mock_run.call_args_list[1].args[0]
+        assert "origin/develop:guides/setup.md" in show_call
 
     def test_root_level_folder_excludes_subdirectory_files(self, monkeypatch):
         from doc_index import ROOT_LEVEL_FOLDER
 
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "README.md\noverview.rst\nguides/setup.md\ncommands/export.md\n"
-        file_content = b"root content"
+        file_content = "root content"
 
-        with (
-            patch("doc_index.run_command_safe") as mock_run,
-            patch("doc_index.subprocess.run") as mock_subprocess,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
-            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
-
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
             result = get_folder_doc_hashes_from_ref(ROOT_LEVEL_FOLDER)
 
         assert result is not None
@@ -375,15 +376,10 @@ class TestGetFolderDocHashesFromRef:
     def test_folder_excludes_files_from_other_folders(self, monkeypatch):
         monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
         ls_output = "guides/setup.md\nguides/ops/health.md\ncommands/export.md\n"
-        file_content = b"content"
+        file_content = "content"
 
-        with (
-            patch("doc_index.run_command_safe") as mock_run,
-            patch("doc_index.subprocess.run") as mock_subprocess,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
-            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
-
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.side_effect = self._mock_run_calls(ls_output, file_content)
             result = get_folder_doc_hashes_from_ref("guides")
 
         assert result is not None

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -245,7 +245,8 @@ class TestFolderNeedsReindex:
         manifest = {"folders": {"guides": {"doc_hashes": hashes}}}
         # Index file must exist for the folder to be considered up-to-date
         save_index("guides", "dummy index content", docs_root=doc_tree)
-        assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is False
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is False
 
     def test_changed_file_triggers_reindex(self, doc_tree):
         hashes = get_folder_doc_hashes("guides", docs_root=doc_tree)
@@ -253,7 +254,8 @@ class TestFolderNeedsReindex:
 
         # Modify a file
         (doc_tree / "guides" / "operations" / "health-checks.rst").write_text("CHANGED")
-        assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
 
     def test_added_file_triggers_reindex(self, doc_tree):
         hashes = get_folder_doc_hashes("guides", docs_root=doc_tree)
@@ -261,7 +263,8 @@ class TestFolderNeedsReindex:
 
         # Add a new file
         (doc_tree / "guides" / "operations" / "new-doc.rst").write_text("New content")
-        assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
 
     def test_uses_ref_hashes_over_disk(self, doc_tree):
         """When ref hashes are available, folder_needs_reindex uses them instead of disk."""

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -15,6 +15,7 @@ from doc_index import (
     get_docs_in_folder,
     get_docs_root,
     get_folder_doc_hashes,
+    get_folder_doc_hashes_from_ref,
     get_or_generate_summary,
     get_summaries_dir,
     get_summary_filename,
@@ -261,6 +262,87 @@ class TestFolderNeedsReindex:
         # Add a new file
         (doc_tree / "guides" / "operations" / "new-doc.rst").write_text("New content")
         assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
+
+    def test_uses_ref_hashes_over_disk(self, doc_tree):
+        """When ref hashes are available, folder_needs_reindex uses them instead of disk."""
+        disk_hashes = get_folder_doc_hashes("guides", docs_root=doc_tree)
+        ref_hashes = {"guides/operations/health-checks.rst": "different_hash_from_main"}
+        manifest = {"folders": {"guides": {"doc_hashes": disk_hashes}}}
+        save_index("guides", "dummy index content", docs_root=doc_tree)
+
+        # Disk hashes match manifest, but ref hashes differ → should trigger reindex
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=ref_hashes):
+            assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is True
+
+    def test_falls_back_to_disk_when_ref_unavailable(self, doc_tree):
+        """When ref hashes return None, falls back to disk hashes."""
+        hashes = get_folder_doc_hashes("guides", docs_root=doc_tree)
+        manifest = {"folders": {"guides": {"doc_hashes": hashes}}}
+        save_index("guides", "dummy index content", docs_root=doc_tree)
+
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is False
+
+
+class TestGetFolderDocHashesFromRef:
+    def test_returns_hashes_from_git_ref(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+        ls_output = "guides/setup.md\nguides/intro.rst\nguides/.hidden/skip.md\n"
+        file_content = b"doc content"
+        expected_hash = hashlib.sha256(file_content).hexdigest()
+
+        with patch("doc_index.run_command_safe") as mock_run, \
+             patch("doc_index.subprocess.run") as mock_subprocess:
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
+
+            result = get_folder_doc_hashes_from_ref("guides")
+
+        assert result is not None
+        assert result["guides/setup.md"] == expected_hash
+        assert result["guides/intro.rst"] == expected_hash
+        assert "guides/.hidden/skip.md" not in result
+
+    def test_returns_none_when_git_fails(self, monkeypatch):
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+
+        with patch("doc_index.run_command_safe") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = get_folder_doc_hashes_from_ref("guides")
+
+        assert result is None
+
+    def test_handles_docs_subfolder(self, monkeypatch):
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
+        ls_output = "docs/commands/export.md\n"
+        file_content = b"export docs"
+
+        with patch("doc_index.run_command_safe") as mock_run, \
+             patch("doc_index.subprocess.run") as mock_subprocess:
+            mock_run.return_value = MagicMock(returncode=0, stdout=ls_output)
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=file_content)
+
+            result = get_folder_doc_hashes_from_ref("commands")
+
+        assert result is not None
+        # Key should be relative to docs root (subfolder stripped)
+        assert "commands/export.md" in result
+
+    def test_uses_custom_base_branch(self, monkeypatch):
+        monkeypatch.setenv("DOCS_BASE_BRANCH", "develop")
+        monkeypatch.delenv("DOCS_SUBFOLDER", raising=False)
+
+        with patch("doc_index.run_command_safe") as mock_run, \
+             patch("doc_index.subprocess.run") as mock_subprocess:
+            mock_run.return_value = MagicMock(returncode=0, stdout="guides/setup.md\n")
+            mock_subprocess.return_value = MagicMock(returncode=0, stdout=b"content")
+
+            get_folder_doc_hashes_from_ref("guides")
+
+        ls_call = mock_run.call_args_list[0].args[0]
+        assert "origin/develop" in ls_call
+        cat_call = mock_subprocess.call_args_list[0].args[0]
+        assert "origin/develop:guides/setup.md" in cat_call
 
 
 # ── Index save/load ──────────────────────────────────────────────────────────

--- a/tests/test_doc_index_extended.py
+++ b/tests/test_doc_index_extended.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.modules.setdefault("openai", MagicMock())
 
@@ -189,7 +189,8 @@ class TestFolderNeedsReindex:
         index_file = index_dir / "guides-operations.index.md"
         index_file.write_text("# Index for guides/operations")
 
-        assert folder_needs_reindex("guides/operations", manifest, doc_tree) is False
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides/operations", manifest, doc_tree) is False
 
     def test_changed_file_needs_reindex(self, doc_tree):
         hashes = get_folder_doc_hashes("guides/operations", doc_tree)
@@ -200,7 +201,8 @@ class TestFolderNeedsReindex:
         index_file.write_text("# Index for guides/operations")
 
         (doc_tree / "guides" / "operations" / "health-checks.rst").write_text("UPDATED CONTENT")
-        assert folder_needs_reindex("guides/operations", manifest, doc_tree) is True
+        with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
+            assert folder_needs_reindex("guides/operations", manifest, doc_tree) is True
 
 
 # ── save_index / load_index ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes index hash comparison on fork PRs and several related issues.

### Index hash comparison (main fix)
- When running on a fork PR, the tool compared manifest hashes against the fork's doc files on disk. If the fork was behind main, stale hashes would match and indexes wouldn't be regenerated — causing incomplete index updates
- Now uses `git cat-file` (binary mode) to read file content from `origin/main` for hash comparison and manifest saving, with fallback to disk hashes when the ref is unavailable
- Index content is also built from `origin/main` via `git show`, so indexes always reflect the base branch. Folders that don't exist on main (e.g., added by a fork PR) are skipped — they'll be indexed after the PR merges
- Adds "Rebind Origin to Main Repository" step to README workflow example so `origin` points to the upstream repo when running on fork PRs

### review-docs on merged PRs
- `[review-docs]` on merged PRs now reads docs from main (read-only checkout) instead of the fork's stale commit
- Uses `git checkout origin/main -- docs_subfolder` instead of creating a branch, so no orphaned branches are left behind
- `[update-docs]` on merged PRs still creates a branch (needs it for pushing)

### Copy-paste fix for review comments
- The review comment used zero-width space characters inside `[update-docs]` to prevent re-triggering the workflow. Users copy-pasting got an invisible character that broke the command
- Replaced with HTML entities (`&#91;`) in `<code>` tags — renders correctly, copies cleanly, still prevents re-triggering

### Other fixes
- `base64 -w 0` in README workflow to prevent line wrapping with long tokens
- `author_association` check added to README workflow example
- `contents: write` permission in README workflow (was `read`)
- Sanitized exception output in checkout error handler
- Distinguish "not found on ref" vs "no doc files on ref" in log messages

## Test plan
- [x] All 398 tests pass (13 new tests added)
- [x] Hash consistency verified against crane's existing manifest — binary hashing matches
- [x] No secrets/tokens exposed in new code paths
- [x] Fallback to disk hashes works when git ref is unavailable
- [ ] Verify on a fork PR where the fork is behind main on doc files
- [ ] Verify `[review-docs]` on a merged PR reads from main
- [ ] Verify copy-pasting `[update-docs]` from review comment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)