### PR TITLE
fix: escape command triggers in PR comments to prevent re-trigger loop

### DIFF
--- a/src/suggest_docs.py
+++ b/src/suggest_docs.py
@@ -275,7 +275,7 @@ def main():
                 msg = (
                     "## 🔍 Spec vs Code Analysis\n\n"
                     "Could not parse Jira issue key from your comment.\n\n"
-                    "Usage: `[review-feature] PROJ-123`"
+                    "Usage: <code>&#91;review-feature] PROJ-123</code>"
                 )
                 msg_file = Path("/tmp/missing_key.md")
                 msg_file.write_text(msg, encoding="utf-8")
@@ -302,8 +302,8 @@ def main():
                     "The following secrets are missing:\n\n"
                     f"{missing_list}\n\n"
                     "Please add them in **Settings → Secrets → Actions** and comment "
-                    "`[review-feature] PROJ-123` again.\n\n"
-                    "You can also use `[review-docs]` or `[update-docs]` which don't require Jira credentials.\n\n"
+                    "<code>&#91;review-feature] PROJ-123</code> again.\n\n"
+                    "You can also use <code>&#91;review-docs]</code> or <code>&#91;update-docs]</code> which don't require Jira credentials.\n\n"
                     "For setup details, see the [configuration guide](https://github.com/redhat-community-ai-tools/code-to-docs#2-configure-secrets)."
                 )
                 msg_file = Path("/tmp/missing_secrets.md")
@@ -745,7 +745,7 @@ def main():
                         confirm_parts.append(
                             "This is a fork PR, so I can't push changes directly. "
                             "The suggested changes are shown above for you to apply.\n\n"
-                            "Once this PR is merged, comment `[update-docs]` again "
+                            "Once this PR is merged, comment <code>&#91;update-docs]</code> again "
                             "and I'll create a docs PR with these updates."
                         )
                     elif docs_subfolder and push_failed:


### PR DESCRIPTION
## Summary
- Bot-posted PR comments on fork PRs contained literal `[update-docs]` in the footer ("Once this PR is merged, comment `[update-docs]` again..."), which re-triggered the workflow when the bot user was in the allowed users list — creating ~20 duplicate "Suggested Documentation Changes" comments (see migtools/crane#794)
- Also escapes `[review-feature]` and `[review-docs]` in error comments posted when Jira credentials are missing, which could cause the same re-trigger loop
- Uses the same HTML entity approach (`&#91;`) as the review comment fix in PR #50

## Test plan
- [x] All 398 tests pass
- [x] Ruff check clean
- [ ] Verify on a fork PR where the bot user is in the allowed users list

🤖 Generated with [Claude Code](https://claude.com/claude-code)