### PR TITLE
fix: preserve multi-line global instructions in [update-docs] comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ Comment on any Pull Request:
 2. Uncheck any files you don't want updated
 3. Comment `[update-docs]` to create a PR with only the checked files
 
-You can guide how the AI generates doc updates by adding instructions in your `[update-docs]` comment — global on the first line, per-file on subsequent lines:
+You can guide how the AI generates doc updates by adding instructions in your `[update-docs]` comment. Lines matching `filename.ext: instruction` are per-file instructions; all other lines are global instructions passed to the LLM:
 
 ```
-[update-docs] keep changes minimal
+[update-docs] keep changes minimal, here are usage examples for context:
+
+## Example usage
+my-tool --flag value
+
 config-ref.rst: only update the CLI usage example
 ```
 

--- a/src/comments.py
+++ b/src/comments.py
@@ -136,13 +136,15 @@ def parse_update_instructions(comment_body):
     """
     Parse global and per-file instructions from an [update-docs] comment.
 
-    Supports two forms:
-      [update-docs] global instruction here
-      pools.rst: only update the set-quota usage line
+    Supports multi-line global instructions with interspersed per-file instructions:
+      [update-docs] keep changes minimal, here are usage examples:
+      ## Example usage
+      some-command --flag value
+      pools.rst: only update the CLI usage line
       health-checks.rst: don't modify existing sections
 
-    The first line after [update-docs] is the global instruction.
-    Subsequent lines matching "<filename>: <instruction>" are per-file.
+    Lines matching "<filename>: <instruction>" are per-file.
+    All other lines are global instructions passed to the LLM.
 
     Args:
         comment_body: The full comment text
@@ -167,22 +169,22 @@ def parse_update_instructions(comment_body):
     # Match lines where the part before ":" looks like a doc file path
     file_pattern = re.compile(r"^([\w./_-]*\.(?:rst|md|adoc))\s*:\s*(.+)$", re.IGNORECASE)
 
-    # First line is global instructions, unless it matches the per-file pattern
-    first_line = lines[0].strip()
-    first_match = file_pattern.match(first_line)
-    if first_match:
-        file_instructions[first_match.group(1).strip()] = first_match.group(2).strip()
-    else:
-        global_instructions = first_line
-
-    # Remaining lines: check for per-file instructions
-    for line in lines[1:]:
-        line = line.strip()
-        if not line:
+    # Separate per-file instructions from global instructions.
+    # Lines matching "filename.ext: instruction" are per-file.
+    # All other lines are global instructions (preserving multi-line content).
+    global_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            global_lines.append("")
             continue
-        file_match = file_pattern.match(line)
+        file_match = file_pattern.match(stripped)
         if file_match:
             file_instructions[file_match.group(1).strip()] = file_match.group(2).strip()
+        else:
+            global_lines.append(stripped)
+
+    global_instructions = "\n".join(global_lines).strip()
 
     if global_instructions:
         print(f"Global instructions: {global_instructions}")

--- a/src/comments.py
+++ b/src/comments.py
@@ -439,7 +439,7 @@ def post_review_comment(
             "- You can add instructions in your <code>&#91;update-docs]</code> comment:"
         )
         comment_parts.append(
-            "  - **Global** (first line): <code>&#91;update-docs] keep changes minimal, don't add new sections</code>"
+            "  - **Global**: <code>&#91;update-docs] keep changes minimal, don't add new sections</code>"
         )
         comment_parts.append(
             "  - **Per-file** (next lines): <code>config-ref.rst: only update the CLI usage example</code>"

--- a/tests/test_comment_parsing.py
+++ b/tests/test_comment_parsing.py
@@ -86,7 +86,7 @@ class TestParseUpdateInstructions:
             "\n"
             "## Per-Stage Flags\n"
             "```bash\n"
-            "my-tool --stage-flag 'Plugin={\"key\": \"value\"}'\n"
+            'my-tool --stage-flag \'Plugin={"key": "value"}\'\n'
             "```\n"
             "pools.rst: only update the CLI section\n"
             "health.md: don't modify existing sections"
@@ -107,7 +107,7 @@ class TestParseUpdateInstructions:
             "\n"
             "Here are usage examples for context:\n"
             "```bash\n"
-            "my-tool --optional-flags '{\"key\": \"value\"}'\n"
+            'my-tool --optional-flags \'{"key": "value"}\'\n'
             "```"
         )
         global_inst, file_inst = parse_update_instructions(comment)

--- a/tests/test_comment_parsing.py
+++ b/tests/test_comment_parsing.py
@@ -75,6 +75,47 @@ class TestParseUpdateInstructions:
         global_inst, file_inst = parse_update_instructions(comment)
         assert global_inst == "global instruction"
 
+    def test_multiline_global_instructions(self):
+        comment = (
+            "[update-docs] Take into account these usage examples:\n"
+            "\n"
+            "## Global Flags\n"
+            "```bash\n"
+            "my-tool --flag value\n"
+            "```\n"
+            "\n"
+            "## Per-Stage Flags\n"
+            "```bash\n"
+            "my-tool --stage-flag 'Plugin={\"key\": \"value\"}'\n"
+            "```\n"
+            "pools.rst: only update the CLI section\n"
+            "health.md: don't modify existing sections"
+        )
+        global_inst, file_inst = parse_update_instructions(comment)
+        assert "Take into account these usage examples:" in global_inst
+        assert "## Global Flags" in global_inst
+        assert "my-tool --flag value" in global_inst
+        assert "## Per-Stage Flags" in global_inst
+        assert file_inst == {
+            "pools.rst": "only update the CLI section",
+            "health.md": "don't modify existing sections",
+        }
+
+    def test_multiline_global_without_per_file(self):
+        comment = (
+            "[update-docs] keep changes minimal\n"
+            "\n"
+            "Here are usage examples for context:\n"
+            "```bash\n"
+            "my-tool --optional-flags '{\"key\": \"value\"}'\n"
+            "```"
+        )
+        global_inst, file_inst = parse_update_instructions(comment)
+        assert "keep changes minimal" in global_inst
+        assert "usage examples" in global_inst
+        assert "my-tool --optional-flags" in global_inst
+        assert file_inst == {}
+
 
 # ── _resolve_file_instructions ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `parse_update_instructions` previously only used the first line after `[update-docs]` as global instructions
- All subsequent lines were only scanned for per-file patterns (`filename.ext: instruction`) and silently discarded if they didn't match
- This meant detailed multi-line context (usage examples, code blocks, explanations) never reached the LLM
- Now all non-file-pattern lines are included in the global instructions, preserving the full context

**Before:** `[update-docs] Take into account these usage examples:` followed by 50 lines of examples → LLM only received the first line

**After:** The entire multi-line content is passed to the LLM as global instructions

## Test plan
- [x] All 400 tests pass (2 new tests for multi-line instructions)
- [x] Ruff check clean
- [x] Existing single-line global instructions still work
- [x] Per-file instructions still correctly extracted from multi-line comments
- [x] Blank lines in global instructions preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)