### PR TITLE
feat: Claude Code plugin for local documentation authoring

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "code-to-docs": {
+      "command": "uv",
+      "args": ["run", "python", "src/mcp_server.py"],
+      "cwd": ".."
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,67 @@
+# Code-to-Docs Claude Code Plugin
+
+A Claude Code plugin for local documentation authoring. Wraps the
+code-to-docs MCP server and adds a skill for updating docs with
+verification steps.
+
+## Plugin vs Action
+
+These are complements, not alternatives:
+
+- **Plugin** (this): for authoring docs before the PR. A local agent can
+  run the CLI, compare `--help` output against docs, build the site, and
+  grep for call sites. Use it at the moment you write the code.
+- **Action** (the GitHub Action): for enforcement on the PR. Catches docs
+  that the author missed and runs the same checks in CI.
+
+## Setup
+
+1. Clone the code-to-docs repo (or add it as a submodule):
+
+   ```bash
+   git clone https://github.com/redhat-community-ai-tools/code-to-docs.git
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   cd code-to-docs
+   uv sync
+   ```
+
+3. Add the plugin to your Claude Code project. Copy or symlink the `plugin/`
+   directory into your project, or add the MCP server config to your
+   project's `.mcp.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "code-to-docs": {
+         "command": "uv",
+         "args": ["run", "python", "src/mcp_server.py"],
+         "cwd": "/path/to/code-to-docs"
+       }
+     }
+   }
+   ```
+
+## Usage
+
+Ask Claude Code to update docs after making code changes:
+
+> "Update the documentation for the CLI flags i just added"
+
+The `update-docs` skill guides the agent through:
+1. Finding affected doc files via the MCP server
+2. Reading style guidelines from `.code-to-docs/style.md`
+3. Making the update
+4. Verifying against actual tool output (running the CLI, building docs,
+   checking code samples)
+
+## Configuration
+
+The plugin respects the same `.code-to-docs/` configuration as the Action:
+
+- `.code-to-docs/style.md` for style guidelines
+- `.code-to-docs/ignore` for file exclusions
+- `.code-to-docs/config.json` for tool settings

--- a/plugin/skills/update-docs/SKILL.md
+++ b/plugin/skills/update-docs/SKILL.md
@@ -1,0 +1,41 @@
+# Update Documentation
+
+Update documentation files to reflect code changes. This skill emphasizes
+**verification**, not just generation.
+
+## When to use
+
+- After making code changes that affect user-facing behavior
+- When adding new CLI flags, configuration options, or API endpoints
+- When changing defaults, removing features, or modifying error messages
+
+## Steps
+
+1. **Identify affected docs**: Use the `find_docs_for_code` MCP tool with the
+   paths of files you changed. If the tool is not available, look for doc files
+   that reference the changed modules.
+
+2. **Read the current doc**: Read the full content of each affected doc file.
+
+3. **Check style guidelines**: If `.code-to-docs/style.md` exists, read it and
+   follow those conventions.
+
+4. **Check ignore list**: If `.code-to-docs/ignore` exists, skip any files that
+   match the patterns.
+
+5. **Make the update**: Edit the doc file to reflect the code change. Be
+   comprehensive but stay grounded:
+   - Document new parameters, options, flags with names, types, defaults
+   - Update existing examples that are now outdated
+   - Do NOT remove content unrelated to your change
+   - Do NOT reorganize sections that are unaffected
+
+6. **Verify the update**:
+   - Run the CLI tool (if applicable) and compare `--help` output against the docs
+   - Check that code samples in the docs are syntactically valid
+   - If a docs build command is available, run it
+   - Diff the documented behavior against actual behavior for at least one claim
+
+7. **Check the diff**: Review your changes. Every line you added should trace
+   back to something in the code change. Every line you removed should be
+   something the code change made incorrect.


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin for docs authoring before the PR. New `plugin/` directory, no `src/` changes.

- **MCP config** (`.mcp.json`): points to the MCP server in `src/`
- **Update-docs skill**: step-by-step instructions emphasizing verification (run CLI, compare output, build, check samples) rather than just generation
- **README**: documents the plugin/Action split clearly (complements, not alternatives)

Respects `.code-to-docs/style.md` and `.code-to-docs/ignore` so local and CI behavior agree.

## Test plan

- [ ] `uv run pytest -v` passes (417 tests, no source changes)
- [ ] Plugin installs in Claude Code and the skill triggers on doc-update requests