### PR TITLE
fix: normalize DOCS_SUBFOLDER trailing slash before CWD comparison

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,8 @@ if [ -n "$PR_HEAD_SHA" ]; then
 fi
 
 if [ -n "$DOCS_SUBFOLDER" ]; then
-  export DOCS_SUBFOLDER="$DOCS_SUBFOLDER"
+  DOCS_SUBFOLDER="${DOCS_SUBFOLDER%/}"
+  export DOCS_SUBFOLDER
 fi
 
 if [ -n "$COMMENT_BODY" ]; then

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -239,7 +239,7 @@ def _get_effective_subfolder():
     Uses ``git rev-parse --show-prefix`` to determine CWD's position
     within the repo, avoiding filesystem heuristics.
     """
-    docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "")
+    docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "").strip().rstrip("/")
     if not docs_subfolder:
         return ""
     result = run_command_safe(["git", "rev-parse", "--show-prefix"], check=False)

--- a/src/doc_index.py
+++ b/src/doc_index.py
@@ -239,7 +239,8 @@ def _get_effective_subfolder():
     Uses ``git rev-parse --show-prefix`` to determine CWD's position
     within the repo, avoiding filesystem heuristics.
     """
-    docs_subfolder = os.environ.get("DOCS_SUBFOLDER", "").strip().rstrip("/")
+    raw = os.environ.get("DOCS_SUBFOLDER", "")
+    docs_subfolder = os.path.normpath(raw).strip("/") if raw.strip() else ""
     if not docs_subfolder:
         return ""
     result = run_command_safe(["git", "rev-parse", "--show-prefix"], check=False)

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -10,6 +10,7 @@ from doc_index import (
     INDEX_DIR,
     SUMMARIES_DIR,
     _get_docs_content_from_ref,
+    _get_effective_subfolder,
     _handle_empty_folder_on_ref,
     checkout_docs_from_base_branch,
     folder_needs_reindex,
@@ -289,6 +290,40 @@ class TestFolderNeedsReindex:
 
         with patch("doc_index.get_folder_doc_hashes_from_ref", return_value=None):
             assert folder_needs_reindex("guides", manifest, docs_root=doc_tree) is False
+
+
+class TestGetEffectiveSubfolder:
+    def test_trailing_slash_normalized(self, monkeypatch):
+        """DOCS_SUBFOLDER with trailing slash should still match CWD prefix."""
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs/")
+        mock_result = MagicMock(returncode=0, stdout="docs/\n")
+        with patch("doc_index.run_command_safe", return_value=mock_result):
+            # Reset log dedup state
+            if hasattr(_get_effective_subfolder, "_last_msg"):
+                delattr(_get_effective_subfolder, "_last_msg")
+            assert _get_effective_subfolder() == ""
+
+    def test_no_trailing_slash(self, monkeypatch):
+        """DOCS_SUBFOLDER without trailing slash matches normally."""
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
+        mock_result = MagicMock(returncode=0, stdout="docs/\n")
+        with patch("doc_index.run_command_safe", return_value=mock_result):
+            if hasattr(_get_effective_subfolder, "_last_msg"):
+                delattr(_get_effective_subfolder, "_last_msg")
+            assert _get_effective_subfolder() == ""
+
+    def test_cwd_not_in_subfolder(self, monkeypatch):
+        """When CWD is not inside DOCS_SUBFOLDER, return the subfolder."""
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
+        mock_result = MagicMock(returncode=0, stdout="\n")
+        with patch("doc_index.run_command_safe", return_value=mock_result):
+            if hasattr(_get_effective_subfolder, "_last_msg"):
+                delattr(_get_effective_subfolder, "_last_msg")
+            assert _get_effective_subfolder() == "docs"
+
+    def test_empty_subfolder(self, monkeypatch):
+        monkeypatch.setenv("DOCS_SUBFOLDER", "")
+        assert _get_effective_subfolder() == ""
 
 
 class TestGetFolderDocHashesFromRef:

--- a/tests/test_doc_index.py
+++ b/tests/test_doc_index.py
@@ -293,14 +293,24 @@ class TestFolderNeedsReindex:
 
 
 class TestGetEffectiveSubfolder:
+    @pytest.fixture(autouse=True)
+    def _reset_log_state(self):
+        yield
+        if hasattr(_get_effective_subfolder, "_last_msg"):
+            delattr(_get_effective_subfolder, "_last_msg")
+
     def test_trailing_slash_normalized(self, monkeypatch):
         """DOCS_SUBFOLDER with trailing slash should still match CWD prefix."""
         monkeypatch.setenv("DOCS_SUBFOLDER", "docs/")
         mock_result = MagicMock(returncode=0, stdout="docs/\n")
         with patch("doc_index.run_command_safe", return_value=mock_result):
-            # Reset log dedup state
-            if hasattr(_get_effective_subfolder, "_last_msg"):
-                delattr(_get_effective_subfolder, "_last_msg")
+            assert _get_effective_subfolder() == ""
+
+    def test_dot_slash_prefix_normalized(self, monkeypatch):
+        """DOCS_SUBFOLDER with ./ prefix should still match CWD prefix."""
+        monkeypatch.setenv("DOCS_SUBFOLDER", "./docs")
+        mock_result = MagicMock(returncode=0, stdout="docs/\n")
+        with patch("doc_index.run_command_safe", return_value=mock_result):
             assert _get_effective_subfolder() == ""
 
     def test_no_trailing_slash(self, monkeypatch):
@@ -308,8 +318,6 @@ class TestGetEffectiveSubfolder:
         monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
         mock_result = MagicMock(returncode=0, stdout="docs/\n")
         with patch("doc_index.run_command_safe", return_value=mock_result):
-            if hasattr(_get_effective_subfolder, "_last_msg"):
-                delattr(_get_effective_subfolder, "_last_msg")
             assert _get_effective_subfolder() == ""
 
     def test_cwd_not_in_subfolder(self, monkeypatch):
@@ -317,13 +325,35 @@ class TestGetEffectiveSubfolder:
         monkeypatch.setenv("DOCS_SUBFOLDER", "docs")
         mock_result = MagicMock(returncode=0, stdout="\n")
         with patch("doc_index.run_command_safe", return_value=mock_result):
-            if hasattr(_get_effective_subfolder, "_last_msg"):
-                delattr(_get_effective_subfolder, "_last_msg")
             assert _get_effective_subfolder() == "docs"
 
     def test_empty_subfolder(self, monkeypatch):
         monkeypatch.setenv("DOCS_SUBFOLDER", "")
         assert _get_effective_subfolder() == ""
+
+    def test_trailing_slash_pathspec_not_doubled(self, monkeypatch):
+        """The actual regression: trailing slash must not cause doubled pathspecs."""
+        monkeypatch.setenv("DOCS_SUBFOLDER", "docs/")
+        monkeypatch.setenv("DOCS_BASE_BRANCH", "main")
+
+        calls = []
+
+        def capture_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "rev-parse" in cmd and "--show-prefix" in cmd:
+                return MagicMock(returncode=0, stdout="docs/\n")
+            if "rev-parse" in cmd and "--verify" in cmd:
+                return MagicMock(returncode=0)
+            if "ls-tree" in cmd:
+                return MagicMock(returncode=0, stdout="")
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("doc_index.run_command_safe", side_effect=capture_run):
+            get_folder_doc_hashes_from_ref("commands")
+
+        ls_tree_calls = [c for c in calls if "ls-tree" in c]
+        assert len(ls_tree_calls) == 1
+        assert ls_tree_calls[0][-1] == "commands"
 
 
 class TestGetFolderDocHashesFromRef:


### PR DESCRIPTION
## Summary

- `DOCS_SUBFOLDER` set with a trailing slash (e.g. `docs/`) caused `_get_effective_subfolder()` to fail its CWD comparison: `git rev-parse --show-prefix` returns `docs/` which gets `rstrip("/")` to `docs`, but the env var was compared as-is — `"docs" != "docs/"` 
- The mismatch kept the subfolder prefix in pathspecs, causing the double-prefix bug (`docs/docs/...`) that made all ref-based reads return empty
- Fix: strip trailing slash from `DOCS_SUBFOLDER` at the start of `_get_effective_subfolder()`

Confirmed by debug logging added in #76:
```
CWD prefix 'docs' != DOCS_SUBFOLDER '***', keeping prefix
```

## Test plan
- [x] 430 tests pass
- [x] Ruff check + format clean
- [x] New `TestGetEffectiveSubfolder` class with 4 tests:
  - Trailing slash normalized and matches CWD
  - No trailing slash matches normally
  - CWD not in subfolder returns subfolder value
  - Empty subfolder returns empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)