### PR TITLE
docs: fix version references to v1 and prep v1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-26
+
+### Fixed
+
+- Normalize `DOCS_SUBFOLDER` trailing slash and resolve paths with
+  `os.path.normpath` before comparing against the current working directory
+- Clean up stale semantic indexes when their documentation files are deleted,
+  fetching the base branch ref for accurate change detection
+- Build git `ls-tree` / `cat-file` / `show` pathspecs relative to the current
+  working directory using `git rev-parse --show-prefix`
+
 ## [0.1.0] - 2026-08-16
 
 Initial tagged release. The action has been in use since September 2025;

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ jobs:
             "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64 -w 0)"
 
       - name: Documentation Assistant
-        uses: redhat-community-ai-tools/code-to-docs@v0
+        uses: redhat-community-ai-tools/code-to-docs@v1
         with:
           model-api-base: ${{ secrets.MODEL_API_BASE }}
           model-api-key: ${{ secrets.MODEL_API_KEY }}
@@ -200,8 +200,8 @@ These are set as `with:` parameters in the workflow step (not as secrets):
 
 ### Versioning
 
-- `@v0` receives all backward-compatible updates (recommended)
-- `@v0.1.0` pins to an exact release
+- `@v1` receives all backward-compatible updates (recommended)
+- `@v1.1.2` pins to an exact release
 - `@main` tracks unreleased changes and is not stable
 
 ### Supported Model Backends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "code-to-docs"
-version = "0.1.0"
+version = "1.1.2"
 description = "GitHub Action that generates documentation suggestions from code changes using LLMs"
 requires-python = ">=3.12"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

The README pointed users to a non-existent `@v0` tag in the setup instructions. The actual release tags are `v1.x` (latest `v1.1.1`), so anyone copy-pasting the workflow snippet hits a "tag not found" error.

This PR aligns the docs and version metadata with the real `v1` tag scheme, and preps a `v1.1.2` release for the fixes already merged since `v1.1.1`.

## Changes

- **README.md** — point users to `@v1` (recommended moving tag) instead of `@v0` in both the workflow snippet and the Versioning section; use `@v1.1.2` as the exact-pin example.
- **CHANGELOG.md** — add the `[1.1.2]` section documenting the fixes landed since `v1.1.1` (DOCS_SUBFOLDER normalization, stale-index cleanup, ls-tree CWD-relative pathspecs).
- **pyproject.toml** — bump `version` `0.1.0` → `1.1.2` (it had drifted at `0.1.0` across every `v1.x` release).

## Notes

- No runtime behavior changes — all three files are docs/metadata; nothing reads the package version at runtime. Safe for `@main` users.
- After merge, pushing the `v1.1.2` tag triggers the release workflow, which runs tests, creates the GitHub Release, and re-points the `v1` major tag (currently stale) to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)